### PR TITLE
Feature/winrm classes module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,4 +3,9 @@
 ---
 fixtures:
   forge_modules:
-#     stdlib: "puppetlabs/stdlib"
+    stdlib: "puppetlabs/stdlib"
+    windows_firewall: "puppet/windows_firewall"
+    powershell: "puppetlabs/powershell"
+    registry: "puppetlabs/registry"
+  symlinks:
+    winrm: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,6 @@
 fixtures:
   forge_modules:
     stdlib: "puppetlabs/stdlib"
-    windows_firewall: "puppet/windows_firewall"
     powershell: "puppetlabs/powershell"
     registry: "puppetlabs/registry"
   symlinks:

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,56 @@
+---
+.gitignore:
+  paths:
+    - .rerun.json
+    - .librarian
+    - .kitchen
+    - .tmp
+    - .bundle
+    - bolt.log
+    - Puppetfile.lock
+    - modules
+.gitlab-ci.yml:
+  # we don't use GitLab
+  unmanaged: true
+appveyor.yml:
+  # we don't use Appveyor
+  unmanaged: true
+Gemfile:
+  required:
+    ':development':
+      - gem: 'puppet-lint-absolute_template_path'
+        version: '>= 1.0.1'
+      - gem: 'puppet-lint-alias-check'
+        version: '>= 0.1.1'
+      - gem: 'puppet-lint-classes_and_types_beginning_with_digits-check'
+        version: '>= 0.1.2'
+      - gem: 'puppet-lint-concatenated_template_files-check'
+        version: '>= 0.1.1'
+      - gem: 'puppet-lint-file_ensure-check'
+        version: '>= 0.3.1'
+      - gem: 'puppet-lint-file_source_rights-check'
+        version: '>= 0.1.1'
+      - gem: 'puppet-lint-leading_zero-check'
+        version: '>= 0.1.1'
+      - gem: 'puppet-lint-resource_reference_syntax'
+        version: '>= 1.0.10'
+      - gem: 'puppet-lint-trailing_comma-check'
+        version: '>= 0.3.2'
+      - gem: 'puppet-lint-unquoted_string-check'
+        version: '>= 0.3.0'
+      - gem: 'puppet-lint-version_comparison-check'
+        version: '>= 0.2.1'
+      - gem: 'r10k'
+        version: '>= 3.0.0'
+      # cri is needed by r10k, but due to a bug in the cri gem v2.15.7 it breaks r10k
+      # see: https://github.com/puppetlabs/r10k/issues/930
+      - gem: 'cri'
+        version: '2.15.6'
+      - gem: 'rspec-json_expectations'
+        version: '>= 2.2.0'
+      - gem: 'yaml-lint'
+        version: '>= 0.0.10'
+# Rakefile:
+#   extras:
+#     - "# exclude plans because puppet-syntax doesn't support them yet: https://github.com/voxpupuli/puppet-syntax/issues/95"
+#     - 'PuppetSyntax.exclude_paths = ["plans/**/*", "vendor/**/*"]'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # WinRM module for Puppet
 
-[![Build Status](https://travis-ci.org/EncoreTechnologies/puppet-winrm.png?branch=master)](https://travis-ci.org/EncoreTechnologies/puppet-winrm)
-[![Code Coverage](https://coveralls.io/repos/github/EncoreTechnologies/puppet-winrm/badge.svg?branch=master)](https://coveralls.io/github/EncoreTechnologies/puppet-winrm)
-[![Puppet Forge](https://img.shields.io/puppetforge/v/encore/winrm.svg)](https://forge.puppetlabs.com/encore/winrm)
-[![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/encore/winrm.svg)](https://forge.puppetlabs.com/encore/winrm)
-[![Puppet Forge - endorsement](https://img.shields.io/puppetforge/e/encore/winrm.svg)](https://forge.puppetlabs.com/encore/winrm)
-[![Puppet Forge - scores](https://img.shields.io/puppetforge/f/encore/winrm.svg)](https://forge.puppetlabs.com/encore/winrm)
+[![Build Status](https://travis-ci.org/EncoreTechnologies/puppet-winrm.svg?branch=master)](https://travis-ci.org/EncoreTechnologies/puppet-winrm)
+[![Puppet Forge Version](https://img.shields.io/puppetforge/v/encore/winrm.svg)](https://forge.puppet.com/encore/winrm)
+[![Puppet Forge Downloads](https://img.shields.io/puppetforge/dt/encore/winrm.svg)](https://forge.puppet.com/encore/winrm)
+[![Puppet Forge Score](https://img.shields.io/puppetforge/f/encore/winrm.svg)](https://forge.puppet.com/encore/winrm)
+[![Puppet PDK Version](https://img.shields.io/puppetforge/pdk-version/encore/winrm.svg)](https://forge.puppet.com/encore/winrm)
+[![puppetmodule.info docs](http://www.puppetmodule.info/images/badge.png)](http://www.puppetmodule.info/m/encore-winrm)
 
 #### Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 #### Table of Contents
 
 1. [Description - What the module does and why it is useful](#module-description)
-1. [Setup - The basics of getting started with winrm](#setup)
-    * [Setup requirements](#setup-requirements)
+1. [Setup - The basics of getting started with winrm](#setup-requirements)
 1. [Usage - Configuration options and additional functionality](#usage)
 1. [Reference - Parameters and explanations](#reference)
 
@@ -19,16 +18,18 @@
 
 This module configures and maintains the WinRM configurations on a Windows system.
 
-## Setup
+## Setup requirements
 
-##Setup requirements
-
-You need to be running powershell 4 or greater for this module to work correctly
+You need to be running powershell 4 or greater for this module to work correctly.
 
 ## Usage
 
-Configure WinRM on Windows servers
+Basic usage:
+```puppet
+class { 'winrm': }
+```
 
+Advanced configuration WinRM on Windows servers:
 ```puppet
 class { 'winrm':
   allow_unencrypted_enable                 => false,
@@ -45,6 +46,14 @@ class { 'winrm':
 }
 ```
 
+Firewall usage:
+```puppet
+class { 'winrm::config::firewall':
+  http_listener_enable  => false,
+  https_listener_enable => true,
+}
+```
+
 ## Reference
 
 ### Parameters
@@ -52,22 +61,62 @@ class { 'winrm':
 #### allow_unencrypted_enable
 
 Is unencrypted traffic allowed? Default is false.
+```puppet
+class { 'winrm::config::allow_unencrypted':
+  allow_unencrypted_enable => false,
+}
+```
 
-#### auth_basic_enable
+#### Auth
+
+##### auth_basic_enable
 
 Is Basic Authentication allowed? Default is false
 
-#### auth_credssp_enable
+##### auth_credssp_enable
 
 Is CredSSP Authentication allowed? Default is false
 
-#### auth_kerberos_enable
+##### auth_kerberos_enable
 
 Is Kerberos Authentication allowed? Default is true
 
-#### auth_negotiate_enable
+##### auth_negotiate_enable
 
 Is Negotiate Authentication allowed? Default is true
+
+```puppet
+class { 'winrm::config::auth':
+  auth_basic_enable     => false,
+  auth_credssp_enable   => false,
+  auth_kerberos_enable  => true,
+  auth_negotiate_enable => true,
+}
+```
+
+#### execution_policy
+
+Server execution policy to follow.
+Available options are: 'AllSigned', 'Bypass', 'RemoteSigned', 'Restricted', 'Undefined', 'Unrestricted'
+Defualt is RemoteSigned
+```puppet
+class { 'winrm::config::execution_policy':
+  execution_policy => 'RemoteSigned',
+}
+```
+
+#### http_listener_enable
+
+Should winrm be listening for http connections. Defialt is false
+```puppet
+class { 'winrm::config::listener::http':
+  http_listener_enable => false,
+}
+```
+
+#### https_listener_enable
+
+Should winrm be listening for https connections. Defialt is true
 
 #### certificate_hash
 
@@ -76,26 +125,30 @@ and used for the HTTPs/SSL listener
 
 #### cert_validity_days
 
+```puppet
+class { 'winrm::config::listener::https':
+  cert_validity_days    => 1095,
+  certificate_hash      => 'test cert hash',
+  https_listener_enable => true,
+}
+```
+
 Length of time in days the Self Signed certificate is good for. Default is 1095
-
-#### execution_policy
-
-Server execution policy to follow.
-Available options are: 'AllSigned', 'Bypass', 'RemoteSigned', 'Restricted', 'Undefined', 'Unrestricted'
-Defualt is RemoteSigned
-
-#### http_listener_enable
-
-Should winrm be listening for http connections. Defialt is false
-
-#### https_listener_enable
-
-Should winrm be listening for https connections. Defialt is true
 
 #### local_account_token_filter_policy_enable
 
 If LocalAccountTokenFilterPolicy should be enabled? Default is true
+```puppet
+class { 'winrm::config::localaccounttokenfilter':
+  local_account_token_filter_policy_enable => true,
+}
+```
 
 #### skip_network_profile_check
 
 If Enable-PSRemoting should skip the network profile check. Default is false
+```puppet
+class { 'winrm::config::ps_remoting':
+  skip_network_profile_check => false,
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,87 +1,84 @@
-# winrm
+# WinRM module for Puppet
 
-Welcome to your new module. A short overview of the generated parts can be found in the PDK documentation at https://puppet.com/docs/pdk/latest/pdk_generating_modules.html .
-
-The README template below provides a starting point with details about what information to include in your README.
+[![Build Status](https://travis-ci.org/EncoreTechnologies/puppet-winrm.png?branch=master)](https://travis-ci.org/EncoreTechnologies/puppet-winrm)
+[![Code Coverage](https://coveralls.io/repos/github/EncoreTechnologies/puppet-winrm/badge.svg?branch=master)](https://coveralls.io/github/EncoreTechnologies/puppet-winrm)
+[![Puppet Forge](https://img.shields.io/puppetforge/v/puppet/winrm.svg)](https://forge.puppetlabs.com/puppet/winrm)
+[![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/puppet/winrm.svg)](https://forge.puppetlabs.com/puppet/winrm)
+[![Puppet Forge - endorsement](https://img.shields.io/puppetforge/e/puppet/winrm.svg)](https://forge.puppetlabs.com/puppet/winrm)
+[![Puppet Forge - scores](https://img.shields.io/puppetforge/f/puppet/winrm.svg)](https://forge.puppetlabs.com/puppet/winrm)
 
 #### Table of Contents
 
-1. [Description](#description)
-2. [Setup - The basics of getting started with winrm](#setup)
-    * [What winrm affects](#what-winrm-affects)
+1. [Description - What the module does and why it is useful](#module-description)
+1. [Setup - The basics of getting started with winrm](#setup)
     * [Setup requirements](#setup-requirements)
-    * [Beginning with winrm](#beginning-with-winrm)
-3. [Usage - Configuration options and additional functionality](#usage)
-4. [Limitations - OS compatibility, etc.](#limitations)
-5. [Development - Guide for contributing to the module](#development)
+1. [Usage - Configuration options and additional functionality](#usage)
+1. [Reference - Parameters and explanations](#reference)
 
-## Description
+## Module Description
 
-Briefly tell users why they might want to use your module. Explain what your module does and what kind of problems users can solve with it.
-
-This should be a fairly short description helps the user decide if your module is what they want.
+This module configures and maintains the WinRM configurations on a Windows system.
 
 ## Setup
 
-### What winrm affects **OPTIONAL**
+##Setup requirements
 
-If it's obvious what your module touches, you can skip this section. For example, folks can probably figure out that your mysql_instance module affects their MySQL instances.
-
-If there's more that they should know about, though, this is the place to mention:
-
-* Files, packages, services, or operations that the module will alter, impact, or execute.
-* Dependencies that your module automatically installs.
-* Warnings or other important notices.
-
-### Setup Requirements **OPTIONAL**
-
-If your module requires anything extra before setting up (pluginsync enabled, another module, etc.), mention it here.
-
-If your most recent release breaks compatibility or requires particular steps for upgrading, you might want to include an additional "Upgrading" section here.
-
-### Beginning with winrm
-
-The very basic steps needed for a user to get the module up and running. This can include setup steps, if necessary, or it can be an example of the most basic use of the module.
+You need to be running powershell 4 or greater for this module to work correctly
 
 ## Usage
 
-Include usage examples for common use cases in the **Usage** section. Show your users how to use your module to solve problems, and be sure to include code examples. Include three to five examples of the most important or common tasks a user can accomplish with your module. Show users how to accomplish more complex tasks that involve different types, classes, and functions working in tandem.
 
 ## Reference
 
-This section is deprecated. Instead, add reference information to your code as Puppet Strings comments, and then use Strings to generate a REFERENCE.md in your module. For details on how to add code comments and generate documentation with Strings, see the Puppet Strings [documentation](https://puppet.com/docs/puppet/latest/puppet_strings.html) and [style guide](https://puppet.com/docs/puppet/latest/puppet_strings_style.html)
+### Parameters
 
-If you aren't ready to use Strings yet, manually create a REFERENCE.md in the root of your module directory and list out each of your module's classes, defined types, facts, functions, Puppet tasks, task plans, and resource types and providers, along with the parameters for each.
+#### allow_unencrypted_enable
 
-For each element (class, defined type, function, and so on), list:
+Is unencrypted traffic allowed? Default is false.
 
-  * The data type, if applicable.
-  * A description of what the element does.
-  * Valid values, if the data type doesn't make it obvious.
-  * Default value, if any.
+#### auth_basic_enable
 
-For example:
+Is Basic Authentication allowed? Default is false
 
-```
-### `pet::cat`
+#### auth_credssp_enable
 
-#### Parameters
+Is CredSSP Authentication allowed? Default is false
 
-##### `meow`
+#### auth_kerberos_enable
 
-Enables vocalization in your cat. Valid options: 'string'.
+Is Kerberos Authentication allowed? Default is true
 
-Default: 'medium-loud'.
-```
+#### auth_negotiate_enable
 
-## Limitations
+Is Negotiate Authentication allowed? Default is true
 
-In the Limitations section, list any incompatibilities, known issues, or other warnings.
+#### certificate_hash
 
-## Development
+If not using a Self Signed Certificate then this hash can be passed in
+and used for the HTTPs/SSL listener
 
-In the Development section, tell other users the ground rules for contributing to your project and how they should submit their work.
+#### cert_validity_days
 
-## Release Notes/Contributors/Etc. **Optional**
+Length of time in days the Self Signed certificate is good for. Default is 1095
 
-If you aren't using changelog, put your release notes here (though you should consider using changelog). You can also add any additional sections you feel are necessary or important to include here. Please use the `## ` header.
+#### execution_policy
+
+Server execution policy to follow.
+Available options are: 'AllSigned', 'Bypass', 'RemoteSigned', 'Restricted', 'Undefined', 'Unrestricted'
+Defualt is RemoteSigned
+
+#### http_listener_enable
+
+Should winrm be listening for http connections. Defialt is false
+
+#### https_listener_enable
+
+Should winrm be listening for https connections. Defialt is true
+
+#### local_account_token_filter_policy_enable
+
+If LocalAccountTokenFilterPolicy should be enabled? Default is true
+
+#### skip_network_profile_check
+
+If Enable-PSRemoting should skip the network profile check. Default is false

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Build Status](https://travis-ci.org/EncoreTechnologies/puppet-winrm.png?branch=master)](https://travis-ci.org/EncoreTechnologies/puppet-winrm)
 [![Code Coverage](https://coveralls.io/repos/github/EncoreTechnologies/puppet-winrm/badge.svg?branch=master)](https://coveralls.io/github/EncoreTechnologies/puppet-winrm)
-[![Puppet Forge](https://img.shields.io/puppetforge/v/puppet/winrm.svg)](https://forge.puppetlabs.com/puppet/winrm)
-[![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/puppet/winrm.svg)](https://forge.puppetlabs.com/puppet/winrm)
-[![Puppet Forge - endorsement](https://img.shields.io/puppetforge/e/puppet/winrm.svg)](https://forge.puppetlabs.com/puppet/winrm)
-[![Puppet Forge - scores](https://img.shields.io/puppetforge/f/puppet/winrm.svg)](https://forge.puppetlabs.com/puppet/winrm)
+[![Puppet Forge](https://img.shields.io/puppetforge/v/encore/winrm.svg)](https://forge.puppetlabs.com/encore/winrm)
+[![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/encore/winrm.svg)](https://forge.puppetlabs.com/encore/winrm)
+[![Puppet Forge - endorsement](https://img.shields.io/puppetforge/e/encore/winrm.svg)](https://forge.puppetlabs.com/encore/winrm)
+[![Puppet Forge - scores](https://img.shields.io/puppetforge/f/encore/winrm.svg)](https://forge.puppetlabs.com/encore/winrm)
 
 #### Table of Contents
 
@@ -27,6 +27,23 @@ You need to be running powershell 4 or greater for this module to work correctly
 
 ## Usage
 
+Configure WinRM on Windows servers
+
+```puppet
+class { 'winrm':
+  allow_unencrypted_enable                 => false,
+  auth_basic_enable                        => false,
+  auth_credssp_enable                      => false,
+  auth_kerberos_enable                     => true,
+  auth_negotiate_enable                    => true,
+  cert_validity_days                       => 1095,
+  execution_policy                         => 'RemoteSigned',
+  http_listener_enable                     => false,
+  https_listener_enable                    => true,
+  local_account_token_filter_policy_enable => true,
+  skip_network_profile_check               => false,
+}
+```
 
 ## Reference
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,35 @@
+class winrm::config {
+
+  assert_private()
+
+  $allow_unencrypted_enable                 = $winrm::params::allow_unencrypted_enable
+  $auth_basic_enable                        = $winrm::params::auth_basic_enable
+  $auth_credssp_enable                      = $winrm::params::auth_credssp_enable
+  $auth_kerberos_enable                     = $winrm::params::auth_kerberos_enable
+  $auth_negotiate_enable                    = $winrm::params::auth_negotiate_enable
+  $certificate_hash                         = $winrm::params::certificate_hash
+  $cert_validity_days                       = $winrm::params::cert_validity_days
+  $execution_policy                         = $winrm::params::execution_policy
+  $http_listener_enable                     = $winrm::params::http_listener_enable
+  $https_listener_enable                    = $winrm::params::https_listener_enable
+  $local_account_token_filter_policy_enable = $winrm::params::local_account_token_filter_policy_enable
+  $skip_network_profile_check               = $winrm::params::skip_network_profile_check
+
+  contain winrm::config::allow_unencrypted
+  contain winrm::config::ps_remoting
+  contain winrm::config::execution_policy
+  contain winrm::config::localaccounttokenfilter
+  contain winrm::config::auth
+  contain winrm::config::lisener:http
+  contain winrm::config::lisener:https
+  contain winrm::config::firewall
+
+  Class['winrm::config::allow_unencrypted']
+  ~> Class['winrm::config::ps_remoting']
+  ~> Class['winrm::config::execution_policy']
+  ~> Class['winrm::config::localaccounttokenfilter']
+  ~> Class['winrm::config::auth']
+  ~> Class['winrm::config::lisener:http']
+  ~> Class['winrm::config::lisener:https']
+  ~> Class['winrm::config::firewall']
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,20 +1,6 @@
 # Contains all items to configure WinRM as well as passing variables to the methods.
 class winrm::config {
-
   assert_private()
-
-  $allow_unencrypted_enable                 = $winrm::params::allow_unencrypted_enable
-  $auth_basic_enable                        = $winrm::params::auth_basic_enable
-  $auth_credssp_enable                      = $winrm::params::auth_credssp_enable
-  $auth_kerberos_enable                     = $winrm::params::auth_kerberos_enable
-  $auth_negotiate_enable                    = $winrm::params::auth_negotiate_enable
-  $certificate_hash                         = $winrm::params::certificate_hash
-  $cert_validity_days                       = $winrm::params::cert_validity_days
-  $execution_policy                         = $winrm::params::execution_policy
-  $http_listener_enable                     = $winrm::params::http_listener_enable
-  $https_listener_enable                    = $winrm::params::https_listener_enable
-  $local_account_token_filter_policy_enable = $winrm::params::local_account_token_filter_policy_enable
-  $skip_network_profile_check               = $winrm::params::skip_network_profile_check
 
   contain winrm::config::allow_unencrypted
   contain winrm::config::ps_remoting

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,8 +20,8 @@ class winrm::config {
   contain winrm::config::execution_policy
   contain winrm::config::localaccounttokenfilter
   contain winrm::config::auth
-  contain winrm::config::listener:http
-  contain winrm::config::listener:https
+  contain winrm::config::listener::http
+  contain winrm::config::listener::https
   contain winrm::config::firewall
 
   Class['winrm::config::allow_unencrypted']
@@ -29,7 +29,7 @@ class winrm::config {
   ~> Class['winrm::config::execution_policy']
   ~> Class['winrm::config::localaccounttokenfilter']
   ~> Class['winrm::config::auth']
-  ~> Class['winrm::config::listener:http']
-  ~> Class['winrm::config::listener:https']
+  ~> Class['winrm::config::listener::http']
+  ~> Class['winrm::config::listener::https']
   ~> Class['winrm::config::firewall']
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,8 +20,8 @@ class winrm::config {
   contain winrm::config::execution_policy
   contain winrm::config::localaccounttokenfilter
   contain winrm::config::auth
-  contain winrm::config::lisener:http
-  contain winrm::config::lisener:https
+  contain winrm::config::listener:http
+  contain winrm::config::listener:https
   contain winrm::config::firewall
 
   Class['winrm::config::allow_unencrypted']
@@ -29,7 +29,7 @@ class winrm::config {
   ~> Class['winrm::config::execution_policy']
   ~> Class['winrm::config::localaccounttokenfilter']
   ~> Class['winrm::config::auth']
-  ~> Class['winrm::config::lisener:http']
-  ~> Class['winrm::config::lisener:https']
+  ~> Class['winrm::config::listener:http']
+  ~> Class['winrm::config::listener:https']
   ~> Class['winrm::config::firewall']
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,3 +1,4 @@
+# Contains all items to configure WinRM as well as passing variables to the methods.
 class winrm::config {
 
   assert_private()

--- a/manifests/config/allow_unencrypted.pp
+++ b/manifests/config/allow_unencrypted.pp
@@ -1,0 +1,18 @@
+# https://www.windows-security.org/b39e2859968e78097aed08388fdf7a01/allow-unencrypted-traffic
+class winrm::config::allow_unencrypted (
+  Boolean $allow_unencrypted_enable = $winrm::allow_unencrypted_enable,
+) {
+  if $allow_unencrypted_enable {
+    exec { 'Allow-Unencrypted-Traffic':
+      command   => 'Set-Item -Path "WSMan:\localhost\Service\AllowUnencrypted" -Value $true',
+      unless    => 'If ((Get-ChildItem WSMan:\localhost\Service\AllowUnencrypted).Value -ne $true) { exit 1 }',
+      provider  => powershell,
+    }
+  } else {
+    exec { 'Block-Unencrypted-Traffic':
+      command   => 'Set-Item -Path "WSMan:\localhost\Service\AllowUnencrypted" -Value $false',
+      unless    => 'If ((Get-ChildItem WSMan:\localhost\Service\AllowUnencrypted).Value -ne $false) { exit 1 }',
+      provider  => powershell,
+    }
+  }
+}

--- a/manifests/config/allow_unencrypted.pp
+++ b/manifests/config/allow_unencrypted.pp
@@ -1,4 +1,5 @@
-# https://www.windows-security.org/b39e2859968e78097aed08388fdf7a01/allow-unencrypted-traffic
+# @summary Conifigures winrm service to allows unencrypted traffic to be transfered.
+#          https://www.windows-security.org/b39e2859968e78097aed08388fdf7a01/allow-unencrypted-traffic
 class winrm::config::allow_unencrypted (
   Boolean $allow_unencrypted_enable = $winrm::allow_unencrypted_enable,
 ) {

--- a/manifests/config/allow_unencrypted.pp
+++ b/manifests/config/allow_unencrypted.pp
@@ -4,15 +4,15 @@ class winrm::config::allow_unencrypted (
 ) {
   if $allow_unencrypted_enable {
     exec { 'Allow-Unencrypted-Traffic':
-      command   => 'Set-Item -Path "WSMan:\localhost\Service\AllowUnencrypted" -Value $true',
-      unless    => 'If ((Get-ChildItem WSMan:\localhost\Service\AllowUnencrypted).Value -ne $true) { exit 1 }',
-      provider  => powershell,
+      command  => 'Set-Item -Path "WSMan:\localhost\Service\AllowUnencrypted" -Value $true',
+      unless   => 'If ((Get-ChildItem WSMan:\localhost\Service\AllowUnencrypted).Value -ne $true) { exit 1 }',
+      provider => powershell,
     }
   } else {
     exec { 'Block-Unencrypted-Traffic':
-      command   => 'Set-Item -Path "WSMan:\localhost\Service\AllowUnencrypted" -Value $false',
-      unless    => 'If ((Get-ChildItem WSMan:\localhost\Service\AllowUnencrypted).Value -ne $false) { exit 1 }',
-      provider  => powershell,
+      command  => 'Set-Item -Path "WSMan:\localhost\Service\AllowUnencrypted" -Value $false',
+      unless   => 'If ((Get-ChildItem WSMan:\localhost\Service\AllowUnencrypted).Value -ne $false) { exit 1 }',
+      provider => powershell,
     }
   }
 }

--- a/manifests/config/allow_unencrypted.pp
+++ b/manifests/config/allow_unencrypted.pp
@@ -1,5 +1,14 @@
 # @summary Conifigures winrm service to allows unencrypted traffic to be transfered.
 #          https://www.windows-security.org/b39e2859968e78097aed08388fdf7a01/allow-unencrypted-traffic
+#
+# @param [Boolean] allow_unencrypted_enable
+#   Is unencrypted traffic allowed? Default is false.
+#
+# @example Usage:
+#   class { 'winrm::config::allow_unencrypted':
+#     allow_unencrypted_enable => false,
+#   }
+#
 class winrm::config::allow_unencrypted (
   Boolean $allow_unencrypted_enable = $winrm::allow_unencrypted_enable,
 ) {

--- a/manifests/config/auth.pp
+++ b/manifests/config/auth.pp
@@ -1,10 +1,10 @@
 # @summary Configures the different authentication methods that will be accepted on the system
 #          https://docs.microsoft.com/en-us/windows/win32/winrm/authentication-for-remote-connections
 class winrm::config::auth (
-  Boolean $basic_enable     = $winrm::auth_basic_enable,
-  Boolean $credssp_enable   = $winrm::auth_credssp_enable,
-  Boolean $kerberos_enable  = $winrm::auth_kerberos_enable,
-  Boolean $negotiate_enable = $winrm::auth_negotiate_enable,
+  Boolean $auth_basic_enable     = $winrm::auth_basic_enable,
+  Boolean $auth_credssp_enable   = $winrm::auth_credssp_enable,
+  Boolean $auth_kerberos_enable  = $winrm::auth_kerberos_enable,
+  Boolean $auth_negotiate_enable = $winrm::auth_negotiate_enable,
 ) {
   exec { 'Configure-Auth':
     command  => template('winrm/auth/auth_settings.ps1.erb'),

--- a/manifests/config/auth.pp
+++ b/manifests/config/auth.pp
@@ -1,0 +1,13 @@
+# https://docs.microsoft.com/en-us/windows/win32/winrm/authentication-for-remote-connections
+class winrm::config::auth (
+  Boolean $basic_enable     = $winrm::auth_basic_enable,
+  Boolean $credssp_enable   = $winrm::auth_credssp_enable,
+  Boolean $kerberos_enable  = $winrm::auth_kerberos_enable,
+  Boolean $negotiate_enable = $winrm::auth_negotiate_enable,
+) {
+  exec { 'Configure Auth':
+    command  => template('winrm/auth/auth_settings.ps1.erb'),
+    provider => 'powershell',
+    onlyif   => template('winrm/auth/auth_settings_onlyif.ps1.erb'),
+  }
+}

--- a/manifests/config/auth.pp
+++ b/manifests/config/auth.pp
@@ -8,6 +8,6 @@ class winrm::config::auth (
   exec { 'Configure-Auth':
     command  => template('winrm/auth/auth_settings.ps1.erb'),
     provider => 'powershell',
-    onlyif   => template('winrm/auth/auth_settings_onlyif.ps1.erb'),
+    unless   => template('winrm/auth/auth_settings_onlyif.ps1.erb'),
   }
 }

--- a/manifests/config/auth.pp
+++ b/manifests/config/auth.pp
@@ -5,7 +5,7 @@ class winrm::config::auth (
   Boolean $kerberos_enable  = $winrm::auth_kerberos_enable,
   Boolean $negotiate_enable = $winrm::auth_negotiate_enable,
 ) {
-  exec { 'Configure Auth':
+  exec { 'Configure-Auth':
     command  => template('winrm/auth/auth_settings.ps1.erb'),
     provider => 'powershell',
     onlyif   => template('winrm/auth/auth_settings_onlyif.ps1.erb'),

--- a/manifests/config/auth.pp
+++ b/manifests/config/auth.pp
@@ -1,5 +1,26 @@
 # @summary Configures the different authentication methods that will be accepted on the system
 #          https://docs.microsoft.com/en-us/windows/win32/winrm/authentication-for-remote-connections
+#
+# @param [Boolean] auth_basic_enable
+#   Is Basic Authentication allowed? Default is false
+#
+# @param [Boolean] auth_credssp_enable
+#   Is CredSSP Authentication allowed? Default is false
+#
+# @param [Boolean] auth_kerberos_enable
+#  Is Kerberos Authentication allowed? Default is true
+#
+# @param [Boolean] auth_negotiate_enable
+#  Is Negotiate Authentication allowed? Default is true
+#
+# @example Usage:
+#   class { 'winrm::config::auth':
+#     auth_basic_enable     => false,
+#     auth_credssp_enable   => false,
+#     auth_kerberos_enable  => true,
+#     auth_negotiate_enable => true,
+#   }
+#
 class winrm::config::auth (
   Boolean $auth_basic_enable     = $winrm::auth_basic_enable,
   Boolean $auth_credssp_enable   = $winrm::auth_credssp_enable,

--- a/manifests/config/auth.pp
+++ b/manifests/config/auth.pp
@@ -1,4 +1,5 @@
-# https://docs.microsoft.com/en-us/windows/win32/winrm/authentication-for-remote-connections
+# @summary Configures the different authentication methods that will be accepted on the system
+#          https://docs.microsoft.com/en-us/windows/win32/winrm/authentication-for-remote-connections
 class winrm::config::auth (
   Boolean $basic_enable     = $winrm::auth_basic_enable,
   Boolean $credssp_enable   = $winrm::auth_credssp_enable,

--- a/manifests/config/execution_policy.pp
+++ b/manifests/config/execution_policy.pp
@@ -1,8 +1,8 @@
-# https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7
+# @summary Configures the execution policy allowed on the system
+#          https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7
 class winrm::config::execution_policy (
   String $execution_policy = $winrm::execution_policy,
 ) {
-
   exec { 'Set-Execution-Policy':
     command  => "Set-ExecutionPolicy -ExecutionPolicy ${execution_policy} -Scope LocalMachine -Force",
     unless   => "If ((Get-ExecutionPolicy -Scope LocalMachine) -ne '${execution_policy}') { exit 1 }",

--- a/manifests/config/execution_policy.pp
+++ b/manifests/config/execution_policy.pp
@@ -1,5 +1,16 @@
 # @summary Configures the execution policy allowed on the system
 #          https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7
+#
+# @param [String] execution_policy
+#  Server execution policy to follow.
+#  Available options are: 'AllSigned', 'Bypass', 'RemoteSigned', 'Restricted', 'Undefined', 'Unrestricted'
+#  Defualt is RemoteSigned
+#
+# @example Usage:
+#   class { 'winrm::config::execution_policy':
+#     execution_policy => 'RemoteSigned',
+#   }
+#
 class winrm::config::execution_policy (
   String $execution_policy = $winrm::execution_policy,
 ) {

--- a/manifests/config/execution_policy.pp
+++ b/manifests/config/execution_policy.pp
@@ -3,7 +3,7 @@ class winrm::config::execution_policy (
   String $execution_policy = $winrm::execution_policy,
 ) {
 
-  exec { 'Enable-PSRemoting':
+  exec { 'Set-Execution-Policy':
     command   => "Set-ExecutionPolicy -ExecutionPolicy ${execution_policy} -Scope LocalMachine -Force",
     unless    => "If ((Get-ExecutionPolicy -Scope LocalMachine) -ne '${execution_policy}') { exit 1 }",
     provider  => powershell,

--- a/manifests/config/execution_policy.pp
+++ b/manifests/config/execution_policy.pp
@@ -1,0 +1,11 @@
+# https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7
+class winrm::config::execution_policy (
+  String $execution_policy = $winrm::execution_policy,
+) {
+
+  exec { 'Enable-PSRemoting':
+    command   => "Set-ExecutionPolicy -ExecutionPolicy ${execution_policy} -Scope LocalMachine -Force",
+    unless    => "If ((Get-ExecutionPolicy -Scope LocalMachine) -ne '${execution_policy}') { exit 1 }",
+    provider  => powershell,
+  }
+}

--- a/manifests/config/execution_policy.pp
+++ b/manifests/config/execution_policy.pp
@@ -4,8 +4,8 @@ class winrm::config::execution_policy (
 ) {
 
   exec { 'Set-Execution-Policy':
-    command   => "Set-ExecutionPolicy -ExecutionPolicy ${execution_policy} -Scope LocalMachine -Force",
-    unless    => "If ((Get-ExecutionPolicy -Scope LocalMachine) -ne '${execution_policy}') { exit 1 }",
-    provider  => powershell,
+    command  => "Set-ExecutionPolicy -ExecutionPolicy ${execution_policy} -Scope LocalMachine -Force",
+    unless   => "If ((Get-ExecutionPolicy -Scope LocalMachine) -ne '${execution_policy}') { exit 1 }",
+    provider => powershell,
   }
 }

--- a/manifests/config/firewall.pp
+++ b/manifests/config/firewall.pp
@@ -23,7 +23,7 @@ class winrm::config::firewall (
     protocol     => 'TCP',
     local_port   => 5985,
     remote_port  => 'any',
-    display_name => 'Windows Remote Management HTTP-In',
+    display_name => 'Windows Remote Management (HTTP-In)',
     description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5985]',
   }
 
@@ -35,7 +35,7 @@ class winrm::config::firewall (
     protocol     => 'TCP',
     local_port   => 5986,
     remote_port  => 'any',
-    display_name => 'Windows Remote Management HTTPS-In',
+    display_name => 'Windows Remote Management (HTTPS-In)',
     description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5986]',
   }
 

--- a/manifests/config/firewall.pp
+++ b/manifests/config/firewall.pp
@@ -1,9 +1,9 @@
 # https://forge.puppet.com/puppet/windows_firewall
 class winrm::config::firewall (
-  Boolean $http_listener_enabled = $winrm::http_listener_enabled,
+  Boolean $http_listener_enable = $winrm::http_listener_enable,
   Boolean $https_listener_enable = $winrm::https_listener_enable,
 ) {
-  if $http_listener_enabled {
+  if $http_listener_enable {
     windows_firewall::exception { 'WINRM HTTP':
       ensure       => present,
       direction    => 'in',

--- a/manifests/config/firewall.pp
+++ b/manifests/config/firewall.pp
@@ -1,0 +1,34 @@
+# https://forge.puppet.com/puppet/windows_firewall
+class winrm::config::firewall (
+  Boolean $http_listener_enabled = $winrm::http_listener_enabled,
+  Boolean $https_listener_enable = $winrm::https_listener_enable,
+) {
+  if $http_listener_enabled {
+    windows_firewall::exception { 'WINRM HTTP':
+      ensure       => present,
+      direction    => 'in',
+      action       => 'allow',
+      enabled      => true,
+      protocol     => 'TCP',
+      local_port   => 5985,
+      remote_port  => 'any',
+      display_name => 'Windows Remote Management HTTP-In',
+      description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5985]',
+    }
+  }
+
+  if $https_listener_enable {
+    windows_firewall::exception { 'WINRM HTTPS':
+      ensure       => present,
+      direction    => 'in',
+      action       => 'allow',
+      enabled      => true,
+      protocol     => 'TCP',
+      local_port   => 5986,
+      remote_port  => 'any',
+      display_name => 'Windows Remote Management HTTPS-In',
+      description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5986]',
+    }
+  }
+
+}

--- a/manifests/config/firewall.pp
+++ b/manifests/config/firewall.pp
@@ -1,6 +1,19 @@
 # @summary Configures the firewall to allow or block connections based on the listeners that are enabled.
 #          We are using an exec resource here because of issues with windows_firewall module
 #          https://forge.puppet.com/puppet/windows_firewall
+#
+# @param [Boolean] http_listener_enable
+#  Should winrm be listening for http connections. Defialt is false
+#
+# @param [Boolean] https_listener_enable
+#  Should winrm be listening for https connections. Defialt is true
+#
+# @example Usage:
+#   class { 'winrm::config::firewall':
+#     http_listener_enable  => false,
+#     https_listener_enable => true,
+#   }
+#
 class winrm::config::firewall (
   Boolean $http_listener_enable = $winrm::http_listener_enable,
   Boolean $https_listener_enable = $winrm::https_listener_enable,

--- a/manifests/config/firewall.pp
+++ b/manifests/config/firewall.pp
@@ -4,31 +4,39 @@ class winrm::config::firewall (
   Boolean $https_listener_enable = $winrm::https_listener_enable,
 ) {
   if $http_listener_enable {
-    windows_firewall::exception { 'WINRM HTTP':
-      ensure       => present,
-      direction    => 'in',
-      action       => 'allow',
-      enabled      => true,
-      protocol     => 'TCP',
-      local_port   => 5985,
-      remote_port  => 'any',
-      display_name => 'Windows Remote Management HTTP-In',
-      description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5985]',
-    }
+    $http_action = 'allow'
+  } else {
+    $http_action = 'block'
   }
 
   if $https_listener_enable {
-    windows_firewall::exception { 'WINRM HTTPS':
-      ensure       => present,
-      direction    => 'in',
-      action       => 'allow',
-      enabled      => true,
-      protocol     => 'TCP',
-      local_port   => 5986,
-      remote_port  => 'any',
-      display_name => 'Windows Remote Management HTTPS-In',
-      description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5986]',
-    }
+    $https_action = 'allow'
+  } else {
+    $https_action = 'block'
+  }
+
+  windows_firewall::exception { 'WINRM HTTP':
+    ensure       => present,
+    direction    => 'in',
+    action       => $http_action,
+    enabled      => true,
+    protocol     => 'TCP',
+    local_port   => 5985,
+    remote_port  => 'any',
+    display_name => 'Windows Remote Management HTTP-In',
+    description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5985]',
+  }
+
+  windows_firewall::exception { 'WINRM HTTPS':
+    ensure       => present,
+    direction    => 'in',
+    action       => $https_action,
+    enabled      => true,
+    protocol     => 'TCP',
+    local_port   => 5986,
+    remote_port  => 'any',
+    display_name => 'Windows Remote Management HTTPS-In',
+    description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5986]',
   }
 
 }

--- a/manifests/config/firewall.pp
+++ b/manifests/config/firewall.pp
@@ -1,5 +1,6 @@
-# We are using an exec resource here because of issues with windows_firewall module
-# https://forge.puppet.com/puppet/windows_firewall
+# @summary Configures the firewall to allow or block connections based on the listeners that are enabled.
+#          We are using an exec resource here because of issues with windows_firewall module
+#          https://forge.puppet.com/puppet/windows_firewall
 class winrm::config::firewall (
   Boolean $http_listener_enable = $winrm::http_listener_enable,
   Boolean $https_listener_enable = $winrm::https_listener_enable,
@@ -11,39 +12,39 @@ class winrm::config::firewall (
   }
 
   # if $http_listener_enable {
-  #   $http_action = 'allow'
+  #  $http_action = 'allow'
   # } else {
-  #   $http_action = 'block'
+  #  $http_action = 'block'
   # }
 
   # if $https_listener_enable {
-  #   $https_action = 'allow'
+  #  $https_action = 'allow'
   # } else {
-  #   $https_action = 'block'
+  #  $https_action = 'block'
   # }
 
   # windows_firewall::exception { 'WINRM HTTP':
-  #   ensure       => present,
-  #   direction    => 'in',
-  #   action       => $http_action,
-  #   enabled      => true,
-  #   protocol     => 'TCP',
-  #   local_port   => 5985,
-  #   remote_port  => 'any',
-  #   display_name => 'Windows Remote Management (HTTP-In)',
-  #   description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5985]',
+  #  ensure       => present,
+  #  direction    => 'in',
+  #  action       => $http_action,
+  #  enabled      => true,
+  #  protocol     => 'TCP',
+  #  local_port   => 5985,
+  #  remote_port  => 'any',
+  #  display_name => 'Windows Remote Management (HTTP-In)',
+  #  description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5985]',
   # }
 
   # windows_firewall::exception { 'WINRM HTTPS':
-  #   ensure       => present,
-  #   direction    => 'in',
-  #   action       => $https_action,
-  #   enabled      => true,
-  #   protocol     => 'TCP',
-  #   local_port   => 5986,
-  #   remote_port  => 'any',
-  #   display_name => 'Windows Remote Management (HTTPS-In)',
-  #   description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5986]',
+  #  ensure       => present,
+  #  direction    => 'in',
+  #  action       => $https_action,
+  #  enabled      => true,
+  #  protocol     => 'TCP',
+  #  local_port   => 5986,
+  #  remote_port  => 'any',
+  #  display_name => 'Windows Remote Management (HTTPS-In)',
+  #  description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5986]',
   # }
 
 }

--- a/manifests/config/firewall.pp
+++ b/manifests/config/firewall.pp
@@ -1,42 +1,49 @@
+# We are using an exec resource here because of issues with windows_firewall module
 # https://forge.puppet.com/puppet/windows_firewall
 class winrm::config::firewall (
   Boolean $http_listener_enable = $winrm::http_listener_enable,
   Boolean $https_listener_enable = $winrm::https_listener_enable,
 ) {
-  if $http_listener_enable {
-    $http_action = 'allow'
-  } else {
-    $http_action = 'block'
+  exec { 'Configure-Firewall-Rules':
+    command  => template('winrm/firewall/firewall_rules.ps1.erb'),
+    provider => 'powershell',
+    unless   => template('winrm/firewall/firewall_rules_onlyif.ps1.erb'),
   }
 
-  if $https_listener_enable {
-    $https_action = 'allow'
-  } else {
-    $https_action = 'block'
-  }
+  # if $http_listener_enable {
+  #   $http_action = 'allow'
+  # } else {
+  #   $http_action = 'block'
+  # }
 
-  windows_firewall::exception { 'WINRM HTTP':
-    ensure       => present,
-    direction    => 'in',
-    action       => $http_action,
-    enabled      => true,
-    protocol     => 'TCP',
-    local_port   => 5985,
-    remote_port  => 'any',
-    display_name => 'Windows Remote Management (HTTP-In)',
-    description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5985]',
-  }
+  # if $https_listener_enable {
+  #   $https_action = 'allow'
+  # } else {
+  #   $https_action = 'block'
+  # }
 
-  windows_firewall::exception { 'WINRM HTTPS':
-    ensure       => present,
-    direction    => 'in',
-    action       => $https_action,
-    enabled      => true,
-    protocol     => 'TCP',
-    local_port   => 5986,
-    remote_port  => 'any',
-    display_name => 'Windows Remote Management (HTTPS-In)',
-    description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5986]',
-  }
+  # windows_firewall::exception { 'WINRM HTTP':
+  #   ensure       => present,
+  #   direction    => 'in',
+  #   action       => $http_action,
+  #   enabled      => true,
+  #   protocol     => 'TCP',
+  #   local_port   => 5985,
+  #   remote_port  => 'any',
+  #   display_name => 'Windows Remote Management (HTTP-In)',
+  #   description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5985]',
+  # }
+
+  # windows_firewall::exception { 'WINRM HTTPS':
+  #   ensure       => present,
+  #   direction    => 'in',
+  #   action       => $https_action,
+  #   enabled      => true,
+  #   protocol     => 'TCP',
+  #   local_port   => 5986,
+  #   remote_port  => 'any',
+  #   display_name => 'Windows Remote Management (HTTPS-In)',
+  #   description  => 'Inbound rule for Windows Remote Management via WS-Management. [TCP 5986]',
+  # }
 
 }

--- a/manifests/config/listener.pp
+++ b/manifests/config/listener.pp
@@ -1,4 +1,4 @@
-# Configures both the http and ssl (https) listeners on system
+# @summary Configures both the http and ssl (https) listeners on system
 class winrm::config::listener {
   contain winrm::config::listener::http
   contain winrm::config::listener::https

--- a/manifests/config/listener.pp
+++ b/manifests/config/listener.pp
@@ -1,3 +1,4 @@
+# Configures both the http and ssl (https) listeners on system
 class winrm::config::listener {
   contain winrm::config::listener::http
   contain winrm::config::listener::https

--- a/manifests/config/listener.pp
+++ b/manifests/config/listener.pp
@@ -1,0 +1,4 @@
+class winrm::config::listener {
+  contain winrm::config::listener::http
+  contain winrm::config::listener::https
+}

--- a/manifests/config/listener/http.pp
+++ b/manifests/config/listener/http.pp
@@ -1,7 +1,7 @@
 # https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/new-wsmaninstance?view=powershell-7
 # https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/remove-wsmaninstance?view=powershell-7
 class winrm::config::listener::http (
-  Boolean $http_listener_enabled = $winrm::http_listener_enabled,
+  Boolean $http_listener_enable = $winrm::http_listener_enable,
 ) {
   if $http_listener_enabled {
     exec { 'Enable-HTTP-Listener':

--- a/manifests/config/listener/http.pp
+++ b/manifests/config/listener/http.pp
@@ -1,6 +1,15 @@
 # @summary Configures the HTTP listener on the system.
 #          https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/new-wsmaninstance?view=powershell-7
 #          https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/remove-wsmaninstance?view=powershell-7
+#
+# @param [Boolean] http_listener_enable
+#  Should winrm be listening for http connections. Defialt is false
+#
+# @example Usage:
+#   class { 'winrm::config::listener::http':
+#     http_listener_enable => false,
+#   }
+#
 class winrm::config::listener::http (
   Boolean $http_listener_enable = $winrm::http_listener_enable,
 ) {

--- a/manifests/config/listener/http.pp
+++ b/manifests/config/listener/http.pp
@@ -3,7 +3,7 @@
 class winrm::config::listener::http (
   Boolean $http_listener_enable = $winrm::http_listener_enable,
 ) {
-  if $http_listener_enabled {
+  if $http_listener_enable {
     exec { 'Enable-HTTP-Listener':
       command   => "New-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTP'}",
       unless    => "If (!((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like 'TRANSPORT=HTTP'})) { exit 1 }",

--- a/manifests/config/listener/http.pp
+++ b/manifests/config/listener/http.pp
@@ -1,5 +1,6 @@
-# https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/new-wsmaninstance?view=powershell-7
-# https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/remove-wsmaninstance?view=powershell-7
+# @summary Configures the HTTP listener on the system.
+#          https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/new-wsmaninstance?view=powershell-7
+#          https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/remove-wsmaninstance?view=powershell-7
 class winrm::config::listener::http (
   Boolean $http_listener_enable = $winrm::http_listener_enable,
 ) {

--- a/manifests/config/listener/http.pp
+++ b/manifests/config/listener/http.pp
@@ -6,13 +6,13 @@ class winrm::config::listener::http (
   if $http_listener_enable {
     exec { 'Enable-HTTP-Listener':
       command   => "New-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTP'}",
-      unless    => "If (!((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like 'TRANSPORT=HTTP'})) { exit 1 }",
+      unless    => "If (!((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like 'TRANSPORT=HTTP'})) { exit 1 } else { exit 0 }",
       provider  => powershell,
     }
   } else {
     exec { 'Disable-HTTP-Listener':
       command   => "Remove-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTP'}",
-      unless    => "If (((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like 'TRANSPORT=HTTP'})) { exit 1 }",
+      unless    => "If (((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like 'TRANSPORT=HTTP'})) { exit 1 } else { exit 0 }",
       provider  => powershell,
     }
   }

--- a/manifests/config/listener/http.pp
+++ b/manifests/config/listener/http.pp
@@ -5,14 +5,14 @@ class winrm::config::listener::http (
 ) {
   if $http_listener_enable {
     exec { 'Enable-HTTP-Listener':
-      command   => "New-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTP'}",
-      unless    => 'Try { If (!((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like "TRANSPORT=HTTP"})) { Write-Output "Here"; exit 1 } else { exit 0 } } Catch { $exception_str = $_ | Out-String; Write-Output "an error occurred: $exception_str" }',
+      command   => 'New-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address="*";Transport="HTTP"}',
+      unless    => 'If (!((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like "TRANSPORT=HTTP"})) { Exit 1 }',
       provider  => powershell,
     }
   } else {
     exec { 'Disable-HTTP-Listener':
-      command   => "Remove-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTP'}",
-      unless    => "If (((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like 'TRANSPORT=HTTP'})) { exit 1 } else { exit 0 }",
+      command   => 'Remove-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address="*";Transport="HTTP"}',
+      unless    => 'If (((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like "TRANSPORT=HTTP"})) { Exit 1 }',
       provider  => powershell,
     }
   }

--- a/manifests/config/listener/http.pp
+++ b/manifests/config/listener/http.pp
@@ -6,7 +6,7 @@ class winrm::config::listener::http (
   if $http_listener_enable {
     exec { 'Enable-HTTP-Listener':
       command   => "New-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTP'}",
-      unless    => "If (!((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like 'TRANSPORT=HTTP'})) { exit 1 } else { exit 0 }",
+      unless    => 'Try { If (!((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like "TRANSPORT=HTTP"})) { Write-Output "Here"; exit 1 } else { exit 0 } } Catch { $exception_str = $_ | Out-String; Write-Output "an error occurred: $exception_str" }',
       provider  => powershell,
     }
   } else {

--- a/manifests/config/listener/http.pp
+++ b/manifests/config/listener/http.pp
@@ -5,15 +5,15 @@ class winrm::config::listener::http (
 ) {
   if $http_listener_enable {
     exec { 'Enable-HTTP-Listener':
-      command   => 'New-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address="*";Transport="HTTP"}',
-      unless    => 'If (!((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like "TRANSPORT=HTTP"})) { Exit 1 }',
-      provider  => powershell,
+      command  => 'New-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address="*";Transport="HTTP"}',
+      unless   => 'If (!((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like "TRANSPORT=HTTP"})) { Exit 1 }',
+      provider => powershell,
     }
   } else {
     exec { 'Disable-HTTP-Listener':
-      command   => 'Remove-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address="*";Transport="HTTP"}',
-      unless    => 'If (((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like "TRANSPORT=HTTP"})) { Exit 1 }',
-      provider  => powershell,
+      command  => 'Remove-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address="*";Transport="HTTP"}',
+      unless   => 'If (((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like "TRANSPORT=HTTP"})) { Exit 1 }',
+      provider => powershell,
     }
   }
 }

--- a/manifests/config/listener/http.pp
+++ b/manifests/config/listener/http.pp
@@ -1,0 +1,19 @@
+# https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/new-wsmaninstance?view=powershell-7
+# https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/remove-wsmaninstance?view=powershell-7
+class winrm::config::listener::http (
+  Boolean $http_listener_enabled = $winrm::http_listener_enabled,
+) {
+  if $http_listener_enabled {
+    exec { 'Enable-HTTP-Listener':
+      command   => "New-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTP'}",
+      unless    => "If (!((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like 'TRANSPORT=HTTP'})) { exit 1 }",
+      provider  => powershell,
+    }
+  } else {
+    exec { 'Disable-HTTP-Listener':
+      command   => "Remove-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTP'}",
+      unless    => "If (((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like 'TRANSPORT=HTTP'})) { exit 1 }",
+      provider  => powershell,
+    }
+  }
+}

--- a/manifests/config/listener/https.pp
+++ b/manifests/config/listener/https.pp
@@ -2,6 +2,24 @@
 #          Will either generate a self signed one or a hash can be passed in.
 #          https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/new-wsmaninstance?view=powershell-7
 #          https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/remove-wsmaninstance?view=powershell-7
+#
+# @param [String] certificate_hash
+#  If not using a Self Signed Certificate then this hash can be passed in
+#  and used for the HTTPs/SSL listener
+#
+# @param [Integer] cert_validity_days
+#  Length of time in days the Self Signed certificate is good for. Default is 1095
+#
+# @param [Boolean] https_listener_enable
+#  Should winrm be listening for https connections. Defialt is true
+#
+# @example Usage:
+#   class { 'winrm::config::listener::https':
+#     cert_validity_days    => 1095,
+#     certificate_hash      => 'test cert hash',
+#     https_listener_enable => true,
+#   }
+#
 class winrm::config::listener::https (
   Boolean $https_listener_enable = $winrm::https_listener_enable,
   String $certificate_hash       = $winrm::certificate_hash,

--- a/manifests/config/listener/https.pp
+++ b/manifests/config/listener/https.pp
@@ -1,5 +1,7 @@
-# https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/new-wsmaninstance?view=powershell-7
-# https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/remove-wsmaninstance?view=powershell-7
+# @summary Configures the SSL (HTTPS) listener on the system. Also attaches a Certificate to the listen.
+#          Will either generate a self signed one or a hash can be passed in.
+#          https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/new-wsmaninstance?view=powershell-7
+#          https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/remove-wsmaninstance?view=powershell-7
 class winrm::config::listener::https (
   Boolean $https_listener_enable = $winrm::https_listener_enable,
   String $certificate_hash       = $winrm::certificate_hash,

--- a/manifests/config/listener/https.pp
+++ b/manifests/config/listener/https.pp
@@ -5,7 +5,7 @@ class winrm::config::listener::https (
   String $certificate_hash       = $winrm::certificate_hash,
   Integer $cert_validity_days    = $winrm::cert_validity_days,
 ) {
-  exec { 'Configure HTTPS Listener':
+  exec { 'Configure-HTTPS-Listener':
     command  => template('winrm/auth/https_listener.ps1.erb'),
     provider => 'powershell',
     onlyif   => template('winrm/auth/https_listener_onlyif.ps1.erb'),

--- a/manifests/config/listener/https.pp
+++ b/manifests/config/listener/https.pp
@@ -6,8 +6,8 @@ class winrm::config::listener::https (
   Integer $cert_validity_days    = $winrm::cert_validity_days,
 ) {
   exec { 'Configure-HTTPS-Listener':
-    command  => template('winrm/auth/https_listener.ps1.erb'),
+    command  => template('winrm/listener/https_listener.ps1.erb'),
     provider => 'powershell',
-    onlyif   => template('winrm/auth/https_listener_onlyif.ps1.erb'),
+    onlyif   => template('winrm/listener/https_listener_onlyif.ps1.erb'),
   }
 }

--- a/manifests/config/listener/https.pp
+++ b/manifests/config/listener/https.pp
@@ -1,0 +1,13 @@
+# https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/new-wsmaninstance?view=powershell-7
+# https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/remove-wsmaninstance?view=powershell-7
+class winrm::config::listener::https (
+  Boolean $https_listener_enable = $winrm::https_listener_enable,
+  String $certificate_hash       = $winrm::certificate_hash,
+  Integer $cert_validity_days    = $winrm::cert_validity_days,
+) {
+  exec { 'Configure HTTPS Listener':
+    command  => template('winrm/auth/https_listener.ps1.erb'),
+    provider => 'powershell',
+    onlyif   => template('winrm/auth/https_listener_onlyif.ps1.erb'),
+  }
+}

--- a/manifests/config/localaccounttokenfilter.pp
+++ b/manifests/config/localaccounttokenfilter.pp
@@ -11,7 +11,7 @@ class winrm::config::localaccounttokenfilter (
   registry_value { 'LocalAccountTokenFilterPolicy':
       path       => 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\LocalAccountTokenFilterPolicy',
       ensure     => present,
-      type       => 'DWORD',
+      type       => 'dword',
       data       => $policy_value,
     }
 }

--- a/manifests/config/localaccounttokenfilter.pp
+++ b/manifests/config/localaccounttokenfilter.pp
@@ -1,0 +1,17 @@
+# https://support.microsoft.com/en-us/help/951016/description-of-user-account-control-and-remote-restrictions-in-windows
+class winrm::config::localaccounttokenfilter (
+  Boolean $policy_enable = $winrm::local_account_token_filter_policy_enable,
+) {
+  if $policy_enable {
+    $policy_value = '1'
+  } else {
+    $policy_value = '0'
+  }
+
+  registry_value { 'LocalAccountTokenFilterPolicy':
+      path       => 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\LocalAccountTokenFilterPolicy',
+      ensure     => present,
+      type       => 'DWORD',
+      data       => $policy_value,
+    }
+}

--- a/manifests/config/localaccounttokenfilter.pp
+++ b/manifests/config/localaccounttokenfilter.pp
@@ -1,9 +1,9 @@
 # @summary Allows the use of a local account to have remote access to the system.
 #          https://support.microsoft.com/en-us/help/951016/description-of-user-account-control-and-remote-restrictions-in-windows
 class winrm::config::localaccounttokenfilter (
-  Boolean $policy_enable = $winrm::local_account_token_filter_policy_enable,
+  Boolean $local_account_token_filter_policy_enable = $winrm::local_account_token_filter_policy_enable,
 ) {
-  if $policy_enable {
+  if $local_account_token_filter_policy_enable {
     $policy_value = '1'
   } else {
     $policy_value = '0'

--- a/manifests/config/localaccounttokenfilter.pp
+++ b/manifests/config/localaccounttokenfilter.pp
@@ -1,5 +1,14 @@
 # @summary Allows the use of a local account to have remote access to the system.
 #          https://support.microsoft.com/en-us/help/951016/description-of-user-account-control-and-remote-restrictions-in-windows
+#
+# @param [Boolean] local_account_token_filter_policy_enable
+#  If LocalAccountTokenFilterPolicy should be enabled? Default is true
+#
+# @example Usage:
+#   class { 'winrm::config::localaccounttokenfilter':
+#     local_account_token_filter_policy_enable => true,
+#   }
+#
 class winrm::config::localaccounttokenfilter (
   Boolean $local_account_token_filter_policy_enable = $winrm::local_account_token_filter_policy_enable,
 ) {

--- a/manifests/config/localaccounttokenfilter.pp
+++ b/manifests/config/localaccounttokenfilter.pp
@@ -1,4 +1,5 @@
-# https://support.microsoft.com/en-us/help/951016/description-of-user-account-control-and-remote-restrictions-in-windows
+# @summary Allows the use of a local account to have remote access to the system.
+#          https://support.microsoft.com/en-us/help/951016/description-of-user-account-control-and-remote-restrictions-in-windows
 class winrm::config::localaccounttokenfilter (
   Boolean $policy_enable = $winrm::local_account_token_filter_policy_enable,
 ) {

--- a/manifests/config/localaccounttokenfilter.pp
+++ b/manifests/config/localaccounttokenfilter.pp
@@ -9,9 +9,9 @@ class winrm::config::localaccounttokenfilter (
   }
 
   registry_value { 'LocalAccountTokenFilterPolicy':
-      path       => 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\LocalAccountTokenFilterPolicy',
-      ensure     => present,
-      type       => 'dword',
-      data       => $policy_value,
+      ensure => present,
+      path   => 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\LocalAccountTokenFilterPolicy',
+      type   => 'dword',
+      data   => $policy_value,
     }
 }

--- a/manifests/config/ps_remoting.pp
+++ b/manifests/config/ps_remoting.pp
@@ -9,7 +9,7 @@ class winrm::config::ps_remoting (
   }
 
   exec { 'Enable-PSRemoting':
-    command  => 'Enable-PSRemoting -Force -ErrorAction Stop',
+    command  => $ps_remoting_cmd,
     unless   => 'If (!(Get-PSSessionConfiguration -Verbose:$false) -or (!(Get-ChildItem WSMan:\localhost\Listener))) { exit 1 }',
     provider => powershell,
   }

--- a/manifests/config/ps_remoting.pp
+++ b/manifests/config/ps_remoting.pp
@@ -1,5 +1,14 @@
 # @summary Configures the use of Powershell remoting
 #          https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/enable-psremoting?view=powershell-7
+#
+# @param [Boolean] skip_network_profile_check
+#  If Enable-PSRemoting should skip the network profile check. Default is false
+#
+# @example Usage:
+#   class { 'winrm::config::ps_remoting':
+#     skip_network_profile_check => false,
+#   }
+#
 class winrm::config::ps_remoting (
   Boolean $skip_network_profile_check = $winrm::skip_network_profile_check,
 ) {

--- a/manifests/config/ps_remoting.pp
+++ b/manifests/config/ps_remoting.pp
@@ -1,4 +1,5 @@
-# https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/enable-psremoting?view=powershell-7
+# @summary Configures the use of Powershell remoting
+#          https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/enable-psremoting?view=powershell-7
 class winrm::config::ps_remoting (
   Boolean $skip_network_profile_check = $winrm::skip_network_profile_check,
 ) {

--- a/manifests/config/ps_remoting.pp
+++ b/manifests/config/ps_remoting.pp
@@ -9,8 +9,8 @@ class winrm::config::ps_remoting (
   }
 
   exec { 'Enable-PSRemoting':
-    command   => 'Enable-PSRemoting -Force -ErrorAction Stop',
-    unless    => 'If (!(Get-PSSessionConfiguration -Verbose:$false) -or (!(Get-ChildItem WSMan:\localhost\Listener))) { exit 1 }',
-    provider  => powershell,
+    command  => 'Enable-PSRemoting -Force -ErrorAction Stop',
+    unless   => 'If (!(Get-PSSessionConfiguration -Verbose:$false) -or (!(Get-ChildItem WSMan:\localhost\Listener))) { exit 1 }',
+    provider => powershell,
   }
 }

--- a/manifests/config/ps_remoting.pp
+++ b/manifests/config/ps_remoting.pp
@@ -1,0 +1,16 @@
+# https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/enable-psremoting?view=powershell-7
+class winrm::config::ps_remoting (
+  Boolean $skip_network_profile_check = $winrm::skip_network_profile_check,
+) {
+  if $skip_network_profile_check {
+    $ps_remoting_cmd = 'Enable-PSRemoting -SkipNetworkProfileCheck -Force -ErrorAction Stop'
+  } else {
+    $ps_remoting_cmd = 'Enable-PSRemoting -Force -ErrorAction Stop'
+  }
+
+  exec { 'Enable-PSRemoting':
+    command   => 'Enable-PSRemoting -Force -ErrorAction Stop',
+    unless    => 'If (!(Get-PSSessionConfiguration -Verbose:$false) -or (!(Get-ChildItem WSMan:\localhost\Listener))) { exit 1 }',
+    provider  => powershell,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,67 @@
+# == Class: winrm
+#
+# This will configure and manage winrm and its configration for remote access
+# to Windows systems
+#
+# === Parameters
+#
+# [*allow_unencrypted_enable*]
+#   Is unencrypted traffic allowed? Default is false.
+#
+# [*auth_basic_enable*]
+#   Is Basic Authentication allowed? Default is false
+#
+# [*auth_credssp_enable*]
+#   Is CredSSP Authentication allowed? Default is false
+#
+# [*auth_kerberos_enable*]
+#  Is Kerberos Authentication allowed? Default is true
+#
+# [*auth_negotiate_enable*]
+#  Is Negotiate Authentication allowed? Default is true
+#
+# [*certificate_hash*]
+#  If not using a Self Signed Certificate then this hash can be passed in
+#  and used for the HTTPs/SSL listener
+#
+# [*cert_validity_days*]
+#  Length of time in days the Self Signed certificate is good for. Default is 1095
+#
+# [*execution_policy*]
+#  Server execution policy to follow.
+#  Available options are: 'AllSigned', 'Bypass', 'RemoteSigned', 'Restricted', 'Undefined', 'Unrestricted'
+#  Defualt is RemoteSigned
+#
+# [*http_listener_enable*]
+#  Should winrm be listening for http connections. Defialt is false
+#
+# [*https_listener_enable*]
+#  Should winrm be listening for https connections. Defialt is true
+#
+# [*local_account_token_filter_policy_enable*]
+#  If LocalAccountTokenFilterPolicy should be enabled? Default is true
+#
+# [*skip_network_profile_check*]
+#  If Enable-PSRemoting should skip the network profile check. Default is false
+#
+class winrm (
+  Boolean $allow_unencrypted_enable                                                                        = $winrm::params::allow_unencrypted_enable,
+  Boolean $auth_basic_enable                                                                               = $winrm::params::auth_basic_enable,
+  Boolean $auth_credssp_enable                                                                             = $winrm::params::auth_credssp_enable,
+  Boolean $auth_kerberos_enable                                                                            = $winrm::params::auth_kerberos_enable,
+  Boolean $auth_negotiate_enable                                                                           = $winrm::params::auth_negotiate_enable,
+  String $certificate_hash                                                                                 = $winrm::params::certificate_hash,
+  Integer $cert_validity_days                                                                              = $winrm::params::cert_validity_days,
+  Enum['AllSigned', 'Bypass', 'RemoteSigned', 'Restricted', 'Undefined', 'Unrestricted'] $execution_policy = $winrm::params::execution_policy,
+  Boolean $http_listener_enable                                                                            = $winrm::params::http_listener_enable,
+  Boolean $https_listener_enable                                                                           = $winrm::params::https_listener_enable,
+  Boolean $local_account_token_filter_policy_enable                                                        = $winrm::params::local_account_token_filter_policy_enable,
+  Boolean $skip_network_profile_check                                                                      = $winrm::params::skip_network_profile_check,
+) inherits winrm::params {
+  contain winrm::service
+  contain winrm::config
+
+  Class['winrm::service']
+  ~> Class['winrm::config']
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,47 +1,43 @@
-# == Class: winrm
-#
-# This will configure and manage winrm and its configration for remote access
+# @summary This will configure and manage winrm and its configration for remote access
 # to Windows systems
 #
-# === Parameters
-#
-# [*allow_unencrypted_enable*]
+# @param [Boolean] allow_unencrypted_enable
 #   Is unencrypted traffic allowed? Default is false.
 #
-# [*auth_basic_enable*]
+# @param [Boolean] auth_basic_enable
 #   Is Basic Authentication allowed? Default is false
 #
-# [*auth_credssp_enable*]
+# @param [Boolean] auth_credssp_enable
 #   Is CredSSP Authentication allowed? Default is false
 #
-# [*auth_kerberos_enable*]
+# @param [Boolean] auth_kerberos_enable
 #  Is Kerberos Authentication allowed? Default is true
 #
-# [*auth_negotiate_enable*]
+# @param [Boolean] auth_negotiate_enable
 #  Is Negotiate Authentication allowed? Default is true
 #
-# [*certificate_hash*]
+# @param [String] certificate_hash
 #  If not using a Self Signed Certificate then this hash can be passed in
 #  and used for the HTTPs/SSL listener
 #
-# [*cert_validity_days*]
+# @param [Integer] cert_validity_days
 #  Length of time in days the Self Signed certificate is good for. Default is 1095
 #
-# [*execution_policy*]
+# @param [String] execution_policy
 #  Server execution policy to follow.
 #  Available options are: 'AllSigned', 'Bypass', 'RemoteSigned', 'Restricted', 'Undefined', 'Unrestricted'
 #  Defualt is RemoteSigned
 #
-# [*http_listener_enable*]
+# @param [Boolean] http_listener_enable
 #  Should winrm be listening for http connections. Defialt is false
 #
-# [*https_listener_enable*]
+# @param [Boolean] https_listener_enable
 #  Should winrm be listening for https connections. Defialt is true
 #
-# [*local_account_token_filter_policy_enable*]
+# @param [Boolean] local_account_token_filter_policy_enable
 #  If LocalAccountTokenFilterPolicy should be enabled? Default is true
 #
-# [*skip_network_profile_check*]
+# @param [Boolean] skip_network_profile_check
 #  If Enable-PSRemoting should skip the network profile check. Default is false
 #
 class winrm (

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,18 +45,19 @@
 #  If Enable-PSRemoting should skip the network profile check. Default is false
 #
 class winrm (
-  Boolean $allow_unencrypted_enable                                                                        = $winrm::params::allow_unencrypted_enable,
-  Boolean $auth_basic_enable                                                                               = $winrm::params::auth_basic_enable,
-  Boolean $auth_credssp_enable                                                                             = $winrm::params::auth_credssp_enable,
-  Boolean $auth_kerberos_enable                                                                            = $winrm::params::auth_kerberos_enable,
-  Boolean $auth_negotiate_enable                                                                           = $winrm::params::auth_negotiate_enable,
-  String $certificate_hash                                                                                 = $winrm::params::certificate_hash,
-  Integer $cert_validity_days                                                                              = $winrm::params::cert_validity_days,
-  Enum['AllSigned', 'Bypass', 'RemoteSigned', 'Restricted', 'Undefined', 'Unrestricted'] $execution_policy = $winrm::params::execution_policy,
-  Boolean $http_listener_enable                                                                            = $winrm::params::http_listener_enable,
-  Boolean $https_listener_enable                                                                           = $winrm::params::https_listener_enable,
-  Boolean $local_account_token_filter_policy_enable                                                        = $winrm::params::local_account_token_filter_policy_enable,
-  Boolean $skip_network_profile_check                                                                      = $winrm::params::skip_network_profile_check,
+  Boolean  $allow_unencrypted_enable                 = $winrm::params::allow_unencrypted_enable,
+  Boolean  $auth_basic_enable                        = $winrm::params::auth_basic_enable,
+  Boolean  $auth_credssp_enable                      = $winrm::params::auth_credssp_enable,
+  Boolean  $auth_kerberos_enable                     = $winrm::params::auth_kerberos_enable,
+  Boolean  $auth_negotiate_enable                    = $winrm::params::auth_negotiate_enable,
+  String   $certificate_hash                         = $winrm::params::certificate_hash,
+  Integer  $cert_validity_days                       = $winrm::params::cert_validity_days,
+  Enum['AllSigned', 'Bypass', 'RemoteSigned', 'Restricted', 'Undefined', 'Unrestricted']
+    $execution_policy                                = $winrm::params::execution_policy,
+  Boolean  $http_listener_enable                     = $winrm::params::http_listener_enable,
+  Boolean  $https_listener_enable                    = $winrm::params::https_listener_enable,
+  Boolean  $local_account_token_filter_policy_enable = $winrm::params::local_account_token_filter_policy_enable,
+  Boolean  $skip_network_profile_check               = $winrm::params::skip_network_profile_check,
 ) inherits winrm::params {
   contain winrm::service
   contain winrm::config

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,7 @@ class winrm::params {
   $certificate_hash = ''
   $cert_validity_days = 1095
   $execution_policy = 'RemoteSigned'
-  $http_listener_enable = true
+  $http_listener_enable = false
   $https_listener_enable = true
   $local_account_token_filter_policy_enable = true
   $skip_network_profile_check = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,42 +1,42 @@
-# === Parameter defaults
+# @summary Parameter defaults
 #
-# [*allow_unencrypted_enable*]
+# @param [Boolean] allow_unencrypted_enable
 #   Is unencrypted traffic allowed? Default is false.
 #
-# [*auth_basic_enable*]
+# @param [Boolean] auth_basic_enable
 #   Is Basic Authentication allowed? Default is false
 #
-# [*auth_credssp_enable*]
+# @param [Boolean] auth_credssp_enable
 #   Is CredSSP Authentication allowed? Default is false
 #
-# [*auth_kerberos_enable*]
+# @param [Boolean] auth_kerberos_enable
 #  Is Kerberos Authentication allowed? Default is true
 #
-# [*auth_negotiate_enable*]
+# @param [Boolean] auth_negotiate_enable
 #  Is Negotiate Authentication allowed? Default is true
 #
-# [*certificate_hash*]
+# @param [String] certificate_hash
 #  If not using a Self Signed Certificate then this hash can be passed in
 #  and used for the HTTPs/SSL listener
 #
-# [*cert_validity_days*]
+# @param [Integer] cert_validity_days
 #  Length of time in days the Self Signed certificate is good for. Default is 1095
 #
-# [*execution_policy*]
+# @param [String] execution_policy
 #  Server execution policy to follow.
 #  Available options are: 'AllSigned', 'Bypass', 'RemoteSigned', 'Restricted', 'Undefined', 'Unrestricted'
 #  Defualt is RemoteSigned
 #
-# [*http_listener_enable*]
+# @param [Boolean] http_listener_enable
 #  Should winrm be listening for http connections. Defialt is false
 #
-# [*https_listener_enable*]
+# @param [Boolean] https_listener_enable
 #  Should winrm be listening for https connections. Defialt is true
 #
-# [*local_account_token_filter_policy_enable*]
+# @param [Boolean] local_account_token_filter_policy_enable
 #  If LocalAccountTokenFilterPolicy should be enabled? Default is true
 #
-# [*skip_network_profile_check*]
+# @param [Boolean] skip_network_profile_check
 #  If Enable-PSRemoting should skip the network profile check. Default is false
 #
 class winrm::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,44 @@
+# === Parameter defaults
+#
+# [*allow_unencrypted_enable*]
+#   Is unencrypted traffic allowed? Default is false.
+#
+# [*auth_basic_enable*]
+#   Is Basic Authentication allowed? Default is false
+#
+# [*auth_credssp_enable*]
+#   Is CredSSP Authentication allowed? Default is false
+#
+# [*auth_kerberos_enable*]
+#  Is Kerberos Authentication allowed? Default is true
+#
+# [*auth_negotiate_enable*]
+#  Is Negotiate Authentication allowed? Default is true
+#
+# [*certificate_hash*]
+#  If not using a Self Signed Certificate then this hash can be passed in
+#  and used for the HTTPs/SSL listener
+#
+# [*cert_validity_days*]
+#  Length of time in days the Self Signed certificate is good for. Default is 1095
+#
+# [*execution_policy*]
+#  Server execution policy to follow.
+#  Available options are: 'AllSigned', 'Bypass', 'RemoteSigned', 'Restricted', 'Undefined', 'Unrestricted'
+#  Defualt is RemoteSigned
+#
+# [*http_listener_enable*]
+#  Should winrm be listening for http connections. Defialt is false
+#
+# [*https_listener_enable*]
+#  Should winrm be listening for https connections. Defialt is true
+#
+# [*local_account_token_filter_policy_enable*]
+#  If LocalAccountTokenFilterPolicy should be enabled? Default is true
+#
+# [*skip_network_profile_check*]
+#  If Enable-PSRemoting should skip the network profile check. Default is false
+#
 class winrm::params {
   $allow_unencrypted_enable = false
   $auth_basic_enable = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,14 @@
+class winrm::params {
+  $allow_unencrypted_enable = false
+  $auth_basic_enable = false
+  $auth_credssp_enable = false
+  $auth_kerberos_enable = true
+  $auth_negotiate_enable = true
+  $certificate_hash = ''
+  $cert_validity_days = 1095
+  $execution_policy = 'RemoteSigned'
+  $http_listener_enable = true
+  $https_listener_enable = true
+  $local_account_token_filter_policy_enable = true
+  $skip_network_profile_check = false
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,16 +1,6 @@
-# Author::    Liam Bennett (mailto:lbennett@opentable.com)
-# Copyright:: Copyright (c) 2013 OpenTable Inc
-# License::   MIT
-
-# == Class winrm::service
-#
-# This class is meant to be called from `winrm`
-# It ensure the service is running
+# @summary Ensure the service is available and running and set to Automatic on boot.
 #
 class winrm::service {
-
-  assert_private()
-
   service { 'WinRM':
     ensure => running,
     # Sets startup type to 'Automatic'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,19 @@
+# Author::    Liam Bennett (mailto:lbennett@opentable.com)
+# Copyright:: Copyright (c) 2013 OpenTable Inc
+# License::   MIT
+
+# == Class winrm::service
+#
+# This class is meant to be called from `winrm`
+# It ensure the service is running
+#
+class winrm::service {
+
+  assert_private()
+
+  service { 'WinRM':
+    ensure => running,
+    # Sets startup type to 'Automatic'
+    enable => true,
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -15,19 +15,15 @@
   "dependencies": [
     {
       "name": "puppet/windows_firewall",
-      "version_requirement": ">= 2.0.2"
-    }
-    {
-      "name": "puppetlabs/powershell",
-      "version_requirement": ">= 3.0.1"
+      "version_requirement": ">= 2.0.2 < 3.0.0"
     },
     {
-      "name": "puppetlabs/pwshlib",
-      "version_requirement": ">= 0.4.0 < 2.0.0"
+      "name": "puppetlabs/powershell",
+      "version_requirement": ">= 3.0.1 < 4.0.0"
     },
     {
       "name": "puppetlabs/registry",
-      "version_requirement": ">= 1.1.4"
+      "version_requirement": ">= 1.1.4 < 2.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -36,7 +32,7 @@
       "operatingsystemrelease": [
         "2019",
         "2016",
-        "2012",
+        "2012"
       ]
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -1,19 +1,42 @@
 {
-  "name": "encore-winrm",
+  "name": "puppet-winrm",
   "version": "0.1.0",
   "author": "Encore Technologies",
-  "summary": "",
+  "summary": "Module for configuring and managing Windows WinRM configurations",
   "license": "Apache-2.0",
-  "source": "",
+  "source": "https://github.com/EncoreTechnologies/puppet-winrm.git",
+  "project_page": "https://github.com/EncoreTechnologies/puppet-winrm",
+  "issues_url": "https://github.com/EncoreTechnologies/puppet-winrm/issues",
+  "tags": [
+    "windows",
+    "winrm",
+    "remote management"
+  ],
   "dependencies": [
-
+    {
+      "name": "puppet/windows_firewall",
+      "version_requirement": ">= 2.0.2"
+    }
+    {
+      "name": "puppetlabs/powershell",
+      "version_requirement": ">= 3.0.1"
+    },
+    {
+      "name": "puppetlabs/pwshlib",
+      "version_requirement": ">= 0.4.0 < 2.0.0"
+    },
+    {
+      "name": "puppetlabs/registry",
+      "version_requirement": ">= 1.1.4"
+    }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "windows",
       "operatingsystemrelease": [
         "2019",
-        "10"
+        "2016",
+        "2012",
       ]
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -14,10 +14,6 @@
   ],
   "dependencies": [
     {
-      "name": "puppet/windows_firewall",
-      "version_requirement": ">= 2.0.2 < 3.0.0"
-    },
-    {
       "name": "puppetlabs/powershell",
       "version_requirement": ">= 3.0.1 < 4.0.0"
     },

--- a/spec/classes/config/allow_unencrypted_spec.rb
+++ b/spec/classes/config/allow_unencrypted_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe 'winrm' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      describe "winrm::config::allow_unencrypted class without any parameters on #{os}" do
+        let(:params) { {} }
+
+        it {
+          is_expected.to contain_exec('Block-Unencrypted-Traffic')
+            .with_command('Set-Item -Path "WSMan:\localhost\Service\AllowUnencrypted" -Value $false')
+            .with_unless('If ((Get-ChildItem WSMan:\localhost\Service\AllowUnencrypted).Value -ne $false) { exit 1 }')
+            .with_provider('powershell')
+        }
+      end
+
+      describe "winrm::config::allow_unencrypted class with false param on #{os}" do
+        let(:params) { { allow_unencrypted_enable: false } }
+
+        it {
+          is_expected.to contain_exec('Block-Unencrypted-Traffic')
+            .with_command('Set-Item -Path "WSMan:\localhost\Service\AllowUnencrypted" -Value $false')
+            .with_unless('If ((Get-ChildItem WSMan:\localhost\Service\AllowUnencrypted).Value -ne $false) { exit 1 }')
+            .with_provider('powershell')
+        }
+      end
+
+      describe "winrm::config::allow_unencrypted class with true param on #{os}" do
+        let(:params) { { allow_unencrypted_enable: true } }
+
+        it {
+          is_expected.to contain_exec('Allow-Unencrypted-Traffic')
+            .with_command('Set-Item -Path "WSMan:\localhost\Service\AllowUnencrypted" -Value $true')
+            .with_unless('If ((Get-ChildItem WSMan:\localhost\Service\AllowUnencrypted).Value -ne $true) { exit 1 }')
+            .with_provider('powershell')
+        }
+      end
+    end
+  end
+end

--- a/spec/classes/config/auth_spec.rb
+++ b/spec/classes/config/auth_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'winrm' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      describe "winrm::config::auth class without any parameters on #{os}" do
+        let(:params) { {} }
+
+        it { is_expected.to contain_exec('Configure-Auth').with_provider('powershell') }
+      end
+
+      describe "winrm::config::auth class with true param on #{os}" do
+        let(:params) { { auth_basic_enable: true, auth_credssp_enable: true, auth_kerberos_enable: true, auth_negotiate_enable: true } }
+
+        it { is_expected.to contain_exec('Configure-Auth').with_provider('powershell') }
+      end
+    end
+  end
+end

--- a/spec/classes/config/execution_policy_spec.rb
+++ b/spec/classes/config/execution_policy_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+describe 'winrm' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      describe "winrm::config::execution_policy class without any parameters on #{os}" do
+        let(:params) { {} }
+
+        it {
+          is_expected.to contain_exec('Set-Execution-Policy')
+            .with_command('Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force')
+            .with_unless("If ((Get-ExecutionPolicy -Scope LocalMachine) -ne 'RemoteSigned') { exit 1 }")
+            .with_provider('powershell')
+        }
+      end
+
+      describe "winrm::config::execution_policy class with RemoteSigned param on #{os}" do
+        let(:params) { { execution_policy: 'RemoteSigned' } }
+
+        it {
+          is_expected.to contain_exec('Set-Execution-Policy')
+            .with_command('Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force')
+            .with_unless("If ((Get-ExecutionPolicy -Scope LocalMachine) -ne 'RemoteSigned') { exit 1 }")
+            .with_provider('powershell')
+        }
+      end
+
+      describe "winrm::config::execution_policy class with AllSigned param on #{os}" do
+        let(:params) { { execution_policy: 'AllSigned' } }
+
+        it {
+          is_expected.to contain_exec('Set-Execution-Policy')
+            .with_command('Set-ExecutionPolicy -ExecutionPolicy AllSigned -Scope LocalMachine -Force')
+            .with_unless("If ((Get-ExecutionPolicy -Scope LocalMachine) -ne 'AllSigned') { exit 1 }")
+            .with_provider('powershell')
+        }
+      end
+
+      describe "winrm::config::execution_policy class with Bypass param on #{os}" do
+        let(:params) { { execution_policy: 'Bypass' } }
+
+        it {
+          is_expected.to contain_exec('Set-Execution-Policy')
+            .with_command('Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope LocalMachine -Force')
+            .with_unless("If ((Get-ExecutionPolicy -Scope LocalMachine) -ne 'Bypass') { exit 1 }")
+            .with_provider('powershell')
+        }
+      end
+
+      describe "winrm::config::execution_policy class with Restricted param on #{os}" do
+        let(:params) { { execution_policy: 'Restricted' } }
+
+        it {
+          is_expected.to contain_exec('Set-Execution-Policy')
+            .with_command('Set-ExecutionPolicy -ExecutionPolicy Restricted -Scope LocalMachine -Force')
+            .with_unless("If ((Get-ExecutionPolicy -Scope LocalMachine) -ne 'Restricted') { exit 1 }")
+            .with_provider('powershell')
+        }
+      end
+
+      describe "winrm::config::execution_policy class with Undefined param on #{os}" do
+        let(:params) { { execution_policy: 'Undefined' } }
+
+        it {
+          is_expected.to contain_exec('Set-Execution-Policy')
+            .with_command('Set-ExecutionPolicy -ExecutionPolicy Undefined -Scope LocalMachine -Force')
+            .with_unless("If ((Get-ExecutionPolicy -Scope LocalMachine) -ne 'Undefined') { exit 1 }")
+            .with_provider('powershell')
+        }
+      end
+
+      describe "winrm::config::execution_policy class with Unrestricted param on #{os}" do
+        let(:params) { { execution_policy: 'Unrestricted' } }
+
+        it {
+          is_expected.to contain_exec('Set-Execution-Policy')
+            .with_command('Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine -Force')
+            .with_unless("If ((Get-ExecutionPolicy -Scope LocalMachine) -ne 'Unrestricted') { exit 1 }")
+            .with_provider('powershell')
+        }
+      end
+    end
+  end
+end

--- a/spec/classes/config/firewall_spec.rb
+++ b/spec/classes/config/firewall_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'winrm' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      describe "winrm::config::firewall class without any parameters on #{os}" do
+        let(:params) { {} }
+
+        it { is_expected.to contain_exec('Configure-Firewall-Rules').with_provider('powershell') }
+      end
+
+      describe "winrm::config::firewall class with true param on #{os}" do
+        let(:params) { { http_listener_enable: true, https_listener_enable: true } }
+
+        it { is_expected.to contain_exec('Configure-Firewall-Rules').with_provider('powershell') }
+      end
+    end
+  end
+end

--- a/spec/classes/config/listener/http_spec.rb
+++ b/spec/classes/config/listener/http_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe 'winrm' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      describe "winrm::config::listener::http class without any parameters on #{os}" do
+        let(:params) { {} }
+
+        it {
+          is_expected.to contain_exec('Disable-HTTP-Listener')
+            .with_command('Remove-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address="*";Transport="HTTP"}')
+            .with_unless('If (((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like "TRANSPORT=HTTP"})) { Exit 1 }')
+            .with_provider('powershell')
+        }
+      end
+
+      describe "winrm::config::listener::http class with param: fakse on #{os}" do
+        let(:params) { { http_listener_enable: false } }
+
+        it {
+          is_expected.to contain_exec('Disable-HTTP-Listener')
+            .with_command('Remove-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address="*";Transport="HTTP"}')
+            .with_unless('If (((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like "TRANSPORT=HTTP"})) { Exit 1 }')
+            .with_provider('powershell')
+        }
+      end
+
+      describe "winrm::config::listener::http class with param: true on #{os}" do
+        let(:params) { { http_listener_enable: true } }
+
+        it {
+          is_expected.to contain_exec('Enable-HTTP-Listener')
+            .with_command('New-WSManInstance -ResourceUri winrm/config/Listener -SelectorSet @{Address="*";Transport="HTTP"}')
+            .with_unless('If (!((Get-ChildItem WSMan:\localhost\Listener) | Where {$_.Keys -like "TRANSPORT=HTTP"})) { Exit 1 }')
+            .with_provider('powershell')
+        }
+      end
+    end
+  end
+end

--- a/spec/classes/config/listener/https_spec.rb
+++ b/spec/classes/config/listener/https_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'winrm' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      describe "winrm::config::listener::https class without any parameters on #{os}" do
+        let(:params) { {} }
+
+        it { is_expected.to contain_exec('Configure-HTTPS-Listener').with_provider('powershell') }
+      end
+
+      describe "winrm::config::listener::https class with false param on #{os}" do
+        let(:params) { { https_listener_enable: false, cert_validity_days: 1234 } }
+
+        it { is_expected.to contain_exec('Configure-HTTPS-Listener').with_provider('powershell') }
+      end
+
+      describe "winrm::config::listener::https class with certificate_hash param on #{os}" do
+        let(:params) { { https_listener_enable: true, certificate_hash: 'hashstring' } }
+
+        it { is_expected.to contain_exec('Configure-HTTPS-Listener').with_provider('powershell') }
+      end
+    end
+  end
+end

--- a/spec/classes/config/listener_spec.rb
+++ b/spec/classes/config/listener_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'winrm' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      describe "winrm::config::listener class without any parameters on #{os}" do
+        it { is_expected.to contain_class('winrm::config::listener::http') }
+        it { is_expected.to contain_class('winrm::config::listener::https') }
+      end
+    end
+  end
+end

--- a/spec/classes/config/localaccounttokenfilter_spec.rb
+++ b/spec/classes/config/localaccounttokenfilter_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe 'winrm' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      describe "winrm::config::localaccounttokenfilter class without any parameters on #{os}" do
+        let(:params) { {} }
+
+        it {
+          is_expected.to contain_registry_value('LocalAccountTokenFilterPolicy')
+            .with_ensure('present')
+            .with_path('HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\LocalAccountTokenFilterPolicy')
+            .with_type('dword')
+            .with_data('1')
+        }
+      end
+
+      describe "winrm::config::localaccounttokenfilter class with true param on #{os}" do
+        let(:params) { { local_account_token_filter_policy_enable: true } }
+
+        it {
+          is_expected.to contain_registry_value('LocalAccountTokenFilterPolicy')
+            .with_ensure('present')
+            .with_path('HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\LocalAccountTokenFilterPolicy')
+            .with_type('dword')
+            .with_data('1')
+        }
+      end
+
+      describe "winrm::config::localaccounttokenfilter class with false param on #{os}" do
+        let(:params) { { local_account_token_filter_policy_enable: false } }
+
+        it {
+          is_expected.to contain_registry_value('LocalAccountTokenFilterPolicy')
+            .with_ensure('present')
+            .with_path('HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\LocalAccountTokenFilterPolicy')
+            .with_type('dword')
+            .with_data('0')
+        }
+      end
+    end
+  end
+end

--- a/spec/classes/config/ps_remoting_spec.rb
+++ b/spec/classes/config/ps_remoting_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe 'winrm' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      describe "winrm::config::ps_remoting class without any parameters on #{os}" do
+        let(:params) { {} }
+
+        it {
+          is_expected.to contain_exec('Enable-PSRemoting')
+            .with_command('Enable-PSRemoting -Force -ErrorAction Stop')
+            .with_unless('If (!(Get-PSSessionConfiguration -Verbose:$false) -or (!(Get-ChildItem WSMan:\localhost\Listener))) { exit 1 }')
+            .with_provider('powershell')
+        }
+      end
+
+      describe "winrm::config::ps_remoting class with param: fakse on #{os}" do
+        let(:params) { { skip_network_profile_check: false } }
+
+        it {
+          is_expected.to contain_exec('Enable-PSRemoting')
+            .with_command('Enable-PSRemoting -Force -ErrorAction Stop')
+            .with_unless('If (!(Get-PSSessionConfiguration -Verbose:$false) -or (!(Get-ChildItem WSMan:\localhost\Listener))) { exit 1 }')
+            .with_provider('powershell')
+        }
+      end
+
+      describe "winrm::config::ps_remoting class with param: true on #{os}" do
+        let(:params) { { skip_network_profile_check: true } }
+
+        it {
+          is_expected.to contain_exec('Enable-PSRemoting')
+            .with_command('Enable-PSRemoting -SkipNetworkProfileCheck -Force -ErrorAction Stop')
+            .with_unless('If (!(Get-PSSessionConfiguration -Verbose:$false) -or (!(Get-ChildItem WSMan:\localhost\Listener))) { exit 1 }')
+            .with_provider('powershell')
+        }
+      end
+    end
+  end
+end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -4,7 +4,6 @@ describe 'winrm' do
   on_supported_os.each do |os, facts|
     context "on #{os} " do
       let :facts do
-        { operatingsystemversion: os }
         facts
       end
 
@@ -13,8 +12,7 @@ describe 'winrm' do
         it { is_expected.to contain_class('winrm::config::ps_remoting').that_comes_before('Class[winrm::config::execution_policy]') }
         it { is_expected.to contain_class('winrm::config::execution_policy').that_comes_before('Class[winrm::config::localaccounttokenfilter]') }
         it {
-          is_expected.to
-          contain_class('winrm::config::localaccounttokenfilter')
+          is_expected.to contain_class('winrm::config::localaccounttokenfilter')
             .that_comes_before('Class[winrm::config::auth]')
         }
         it { is_expected.to contain_class('winrm::config::auth').that_comes_before('Class[winrm::config::listener::http]') }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'winrm' do
   on_supported_os.each do |os, facts|
-    context "on #{os} " do
+    context "on #{os}" do
       let :facts do
         facts
       end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'winrm' do
+  on_supported_os.each do |os, facts|
+    context "on #{os} " do
+      let :facts do
+        { operatingsystemversion: os }
+        facts
+      end
+
+      describe "winrm::config class without any parameters on #{os}" do
+        it { is_expected.to contain_class('winrm::config::allow_unencrypted').that_comes_before('Class[winrm::config::ps_remoting]') }
+        it { is_expected.to contain_class('winrm::config::ps_remoting').that_comes_before('Class[winrm::config::execution_policy]') }
+        it { is_expected.to contain_class('winrm::config::execution_policy').that_comes_before('Class[winrm::config::localaccounttokenfilter]') }
+        it {
+          is_expected.to
+          contain_class('winrm::config::localaccounttokenfilter')
+            .that_comes_before('Class[winrm::config::auth]')
+        }
+        it { is_expected.to contain_class('winrm::config::auth').that_comes_before('Class[winrm::config::listener::http]') }
+        it { is_expected.to contain_class('winrm::config::listener::http').that_comes_before('Class[winrm::config::listener::https]') }
+        it { is_expected.to contain_class('winrm::config::listener::https').that_comes_before('Class[winrm::config::firewall]') }
+        it { is_expected.to contain_class('winrm::config::firewall') }
+      end
+    end
+  end
+end

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,0 +1,3 @@
+require 'spec_helper'
+
+at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'winrm' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      describe "winrm class without any parameters on #{os}" do
+        let(:params) { {} }
+
+        it { is_expected.to contain_service('WinRM').with_enable(true) }
+      end
+    end
+  end
+end

--- a/spec/classes/winrm_spec.rb
+++ b/spec/classes/winrm_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'winrm' do
+  on_supported_os.each do |os, facts|
+    context "on #{os} " do
+      let :facts do
+        facts
+      end
+
+      describe "winrm class without any parameters on #{os}" do
+        let(:params) { {} }
+
+        # it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('winrm::params') }
+        it { is_expected.to contain_class('winrm::service').that_comes_before('Class[winrm::config]') }
+        it { is_expected.to contain_class('winrm::config') }
+      end
+    end
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,17 @@
+require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
+
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+install_module
+install_module_dependencies
+
+RSpec.configure do |c|
+  # Readable test descriptions
+  c.formatter = :documentation
+  hosts.each do |host|
+    if host[:platform] =~ %r{el-7-x86_64} && host[:hypervisor] =~ %r{docker}
+      on(host, "sed -i '/nodocs/d' /etc/yum.conf")
+    end
+  end
+end

--- a/templates/auth/auth_settings.ps1.erb
+++ b/templates/auth/auth_settings.ps1.erb
@@ -51,9 +51,9 @@ Try {
   $NegotiateEnable = Convert-StringToBoolean -BoolString '<%= @negotiate_enable %>'
 
   Check-AuthSetting -AuthType "Basic" -AuthValue $BasicEnable
-  Check-AuthSetting -AuthType "Kerberos" -AuthValue $CredSSPEnable
-  Check-AuthSetting -AuthType "Negotiate" -AuthValue $KerberosEnable
-  Check-AuthSetting -AuthType "CredSSP" -AuthValue $NegotiateEnable
+  Check-AuthSetting -AuthType "CredSSP" -AuthValue $CredSSPEnable
+  Check-AuthSetting -AuthType "Kerberos" -AuthValue $KerberosEnable
+  Check-AuthSetting -AuthType "Negotiate" -AuthValue $NegotiateEnable
 } Catch {
   $exception_str = $_ | Out-String
   Write-Output "[$(Get-Date -Format 'o')] an error occurred: $exception_str"

--- a/templates/auth/auth_settings.ps1.erb
+++ b/templates/auth/auth_settings.ps1.erb
@@ -45,10 +45,10 @@ function Convert-StringToBoolean {
 $ErrorActionPreference = "Stop"
 
 Try {
-  $BasicEnable = Convert-StringToBoolean -BoolString '<%= @basic_enable %>'
-  $CredSSPEnable = Convert-StringToBoolean -BoolString '<%= @credssp_enable %>'
-  $KerberosEnable = Convert-StringToBoolean -BoolString '<%= @kerberos_enable %>'
-  $NegotiateEnable = Convert-StringToBoolean -BoolString '<%= @negotiate_enable %>'
+  $BasicEnable = Convert-StringToBoolean -BoolString '<%= @auth_basic_enable %>'
+  $CredSSPEnable = Convert-StringToBoolean -BoolString '<%= @auth_credssp_enable %>'
+  $KerberosEnable = Convert-StringToBoolean -BoolString '<%= @auth_kerberos_enable %>'
+  $NegotiateEnable = Convert-StringToBoolean -BoolString '<%= @auth_negotiate_enable %>'
 
   Check-AuthSetting -AuthType "Basic" -AuthValue $BasicEnable
   Check-AuthSetting -AuthType "CredSSP" -AuthValue $CredSSPEnable

--- a/templates/auth/auth_settings.ps1.erb
+++ b/templates/auth/auth_settings.ps1.erb
@@ -1,0 +1,61 @@
+# Check Auth configurations
+# -----------------------------------------------------------
+#
+# This script checks the current Auth configurations vs the
+# passed in values.
+function Check-AuthSetting {
+  Param (
+    [string]$AuthType,
+    [boolean]$AuthValue
+  )
+
+  $authSetting = Get-ChildItem WSMan:\localhost\Service\Auth | Where-Object {$_.Name -eq $AuthType}
+  If (($authSetting.Value) -ne $AuthValue) {
+    If ($AuthType -eq "CredSSP") {
+      If ($AuthValue) {
+        # https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/enable-wsmancredssp?view=powershell-7
+        Enable-WSManCredSSP -role server -Force
+      } Else {
+        # https://docs.microsoft.com/en-us/powershell/module/microsoft.wsman.management/disable-wsmancredssp?view=powershell-7
+        Disable-WSManCredSSP -role server
+      }
+    } Else {
+      $auth_path = "WSMan:\localhost\Service\Auth\$AuthType"
+      Set-Item -Path $auth_path -Value $AuthValue
+    }
+  }
+}
+
+# Puppet does not give the booleans to powershell in the correct way, they are given as strings.
+# So once given we need to convert them to true booleans so that the logic below will work
+function Convert-StringToBoolean {
+  Param (
+    [string]$BoolString
+  )
+
+  $boolReturn = $true
+  If ($BoolString.ToLower() -eq 'false') {
+    $boolReturn = $false
+  }
+
+  return $boolReturn
+}
+
+# Setup error handling.
+$ErrorActionPreference = "Stop"
+
+Try {
+  $BasicEnable = Convert-StringToBoolean -BoolString '<%= @basic_enable %>'
+  $CredSSPEnable = Convert-StringToBoolean -BoolString '<%= @credssp_enable %>'
+  $KerberosEnable = Convert-StringToBoolean -BoolString '<%= @kerberos_enable %>'
+  $NegotiateEnable = Convert-StringToBoolean -BoolString '<%= @negotiate_enable %>'
+
+  Check-AuthSetting -AuthType "Basic" -AuthValue $BasicEnable
+  Check-AuthSetting -AuthType "Kerberos" -AuthValue $CredSSPEnable
+  Check-AuthSetting -AuthType "Negotiate" -AuthValue $KerberosEnable
+  Check-AuthSetting -AuthType "CredSSP" -AuthValue $NegotiateEnable
+} Catch {
+  $exception_str = $_ | Out-String
+  Write-Output "[$(Get-Date -Format 'o')] an error occurred: $exception_str"
+  Exit 1
+}

--- a/templates/auth/auth_settings_onlyif.ps1.erb
+++ b/templates/auth/auth_settings_onlyif.ps1.erb
@@ -34,10 +34,10 @@ function Convert-StringToBoolean {
 $ErrorActionPreference = "Stop"
 
 Try {
-  $BasicEnable = Convert-StringToBoolean -BoolString '<%= @basic_enable %>'
-  $CredSSPEnable = Convert-StringToBoolean -BoolString '<%= @credssp_enable %>'
-  $KerberosEnable = Convert-StringToBoolean -BoolString '<%= @kerberos_enable %>'
-  $NegotiateEnable = Convert-StringToBoolean -BoolString '<%= @negotiate_enable %>'
+  $BasicEnable = Convert-StringToBoolean -BoolString '<%= @auth_basic_enable %>'
+  $CredSSPEnable = Convert-StringToBoolean -BoolString '<%= @auth_credssp_enable %>'
+  $KerberosEnable = Convert-StringToBoolean -BoolString '<%= @auth_kerberos_enable %>'
+  $NegotiateEnable = Convert-StringToBoolean -BoolString '<%= @auth_negotiate_enable %>'
 
   Check-AuthSetting -AuthType "Basic" -AuthValue $BasicEnable
   Check-AuthSetting -AuthType "CredSSP" -AuthValue $CredSSPEnable

--- a/templates/auth/auth_settings_onlyif.ps1.erb
+++ b/templates/auth/auth_settings_onlyif.ps1.erb
@@ -1,0 +1,50 @@
+# Check Auth configurations
+# -----------------------------------------------------------
+#
+# This script checks the current Auth configurations vs the
+# passed in values.
+function Check-AuthSetting {
+  Param (
+    [string]$AuthType,
+    [boolean]$AuthValue
+  )
+
+  $authSetting = Get-ChildItem WSMan:\localhost\Service\Auth | Where-Object {$_.Name -eq $AuthType}
+  If (($authSetting.Value) -ne $AuthValue) {
+    Exit 0
+  }
+}
+
+# Puppet does not give the booleans to powershell in the correct way, they are given as strings.
+# So once given we need to convert them to true booleans so that the logic below will work
+function Convert-StringToBoolean {
+  Param (
+    [string]$BoolString
+  )
+
+  $boolReturn = $true
+  If ($BoolString.ToLower() -eq 'false') {
+    $boolReturn = $false
+  }
+
+  return $boolReturn
+}
+
+# Setup error handling.
+$ErrorActionPreference = "Stop"
+
+Try {
+  $BasicEnable = Convert-StringToBoolean -BoolString '<%= @basic_enable %>'
+  $CredSSPEnable = Convert-StringToBoolean -BoolString '<%= @credssp_enable %>'
+  $KerberosEnable = Convert-StringToBoolean -BoolString '<%= @kerberos_enable %>'
+  $NegotiateEnable = Convert-StringToBoolean -BoolString '<%= @negotiate_enable %>'
+
+  Check-AuthSetting -AuthType "Basic" -AuthValue $BasicEnable
+  Check-AuthSetting -AuthType "Kerberos" -AuthValue $CredSSPEnable
+  Check-AuthSetting -AuthType "Negotiate" -AuthValue $KerberosEnable
+  Check-AuthSetting -AuthType "CredSSP" -AuthValue $NegotiateEnable
+} Catch {
+  $exception_str = $_ | Out-String
+  Write-Output "[$(Get-Date -Format 'o')] an error occurred: $exception_str"
+  Exit 1
+}

--- a/templates/auth/auth_settings_onlyif.ps1.erb
+++ b/templates/auth/auth_settings_onlyif.ps1.erb
@@ -40,9 +40,9 @@ Try {
   $NegotiateEnable = Convert-StringToBoolean -BoolString '<%= @negotiate_enable %>'
 
   Check-AuthSetting -AuthType "Basic" -AuthValue $BasicEnable
-  Check-AuthSetting -AuthType "Kerberos" -AuthValue $CredSSPEnable
-  Check-AuthSetting -AuthType "Negotiate" -AuthValue $KerberosEnable
-  Check-AuthSetting -AuthType "CredSSP" -AuthValue $NegotiateEnable
+  Check-AuthSetting -AuthType "CredSSP" -AuthValue $CredSSPEnable
+  Check-AuthSetting -AuthType "Kerberos" -AuthValue $KerberosEnable
+  Check-AuthSetting -AuthType "Negotiate" -AuthValue $NegotiateEnable
 } Catch {
   $exception_str = $_ | Out-String
   Write-Output "[$(Get-Date -Format 'o')] an error occurred: $exception_str"

--- a/templates/auth/auth_settings_onlyif.ps1.erb
+++ b/templates/auth/auth_settings_onlyif.ps1.erb
@@ -11,7 +11,7 @@ function Check-AuthSetting {
 
   $authSetting = Get-ChildItem WSMan:\localhost\Service\Auth | Where-Object {$_.Name -eq $AuthType}
   If (($authSetting.Value) -ne $AuthValue) {
-    Exit 0
+    Exit 1
   }
 }
 

--- a/templates/firewall/firewall_rules.ps1.erb
+++ b/templates/firewall/firewall_rules.ps1.erb
@@ -1,0 +1,132 @@
+# Check Firewall configurations
+# -----------------------------------------------------------
+#
+# This script checks the current firewall configurations against
+# what is passed in and changes them if neccessary using netsh
+# commands. We use netsh commands instead of the powershell
+# commandlets due to speed, functionality, and backwards compatibility
+function Get-NetshRule {
+  Param (
+    [string]$RuleName
+  )
+  $AllRules = @()
+
+  # Get all enabled rules
+  $Rules = netsh advfirewall firewall show rule status=enabled name="$RuleName"
+
+  # Check if rules are returened
+  $NoMatchString = "No rules match the specified criteria."
+  If ($Rules -eq $NoMatchString) {
+    Return $AllRules
+  }
+
+  # Verify the return is an array
+  If ($Rules -ne [System.Array] ) {
+    $Rules = @($Rules)
+  }
+
+  $SwitchProperties = @{}
+  ForEach ($Rule in $Rules) {
+    # $RuleObject = @{}
+    # Matches is a variable created by the switch that is an object of the matching text
+    # We add to the list on the last property of the rule because the Switch Regex separates
+    # into individual line creating the object in the current context.
+    # Sample rule below:
+    #   Rule Name:                            Windows Remote Management (HTTP-In)
+    #   ----------------------------------------------------------------------
+    #   Enabled:                              Yes
+    #   Direction:                            In
+    #   Profiles:                             Domain,Private
+    #   Grouping:                             Windows Remote Management
+    #   LocalIP:                              Any
+    #   RemoteIP:                             Any
+    #   Protocol:                             TCP
+    #   LocalPort:                            5985
+    #   RemotePort:                           Any
+    #   Edge traversal:                       No
+    #   Action:                               Allow
+    Switch -Regex ($Rule) {
+      '^Rule Name:\s+(?<RuleName>.*$)' { $SwitchProperties.RuleName = $Matches.RuleName; }
+      '^Enabled:\s+(?<Enabled>.*$)' { $SwitchProperties.Enabled = $Matches.Enabled; }
+      '^Direction:\s+(?<Direction>.*$)' { $SwitchProperties.Direction = $Matches.Direction; }
+      '^Profiles:\s+(?<Profiles>.*$)' { $SwitchProperties.Profiles = $Matches.Profiles; }
+      '^Grouping:\s+(?<Grouping>.*$)' { $SwitchProperties.Grouping = $Matches.Grouping; }
+      '^LocalIP:\s+(?<LocalIP>.*$)' { $SwitchProperties.LocalIP = $Matches.LocalIP; }
+      '^RemoteIP:\s+(?<RemoteIP>.*$)' { $SwitchProperties.RemoteIP = $Matches.RemoteIP; }
+      '^Protocol:\s+(?<Protocol>.*$)' { $SwitchProperties.Protocol = $Matches.Protocol; }
+      '^LocalPort:\s+(?<LocalPort>.*$)' { $SwitchProperties.LocalPort = $Matches.LocalPort; }
+      '^RemotePort:\s+(?<RemotePort>.*$)' { $SwitchProperties.RemotePort = $Matches.RemotePort; }
+      '^Edge traversal:\s+(?<Edge_traversal>.*$)' { $SwitchProperties.EdgeTraversal = $Matches.Edge_traversal; }
+      '^Action:\s+(?<Action>.*$)' { $SwitchProperties.Action = $Matches.Action; $RuleObject = New-Object psobject -Property $SwitchProperties; $AllRules += $RuleObject; }
+      # Ignore any other lines that do not match above. Should only be: -------
+      Default { Break }
+    }
+  }
+
+  Return $AllRules
+}
+
+function Convert-StringToBoolean {
+  Param (
+    [string]$BoolString
+  )
+
+  $boolReturn = $true
+  If ($BoolString.ToLower() -eq 'false') {
+    $boolReturn = $false
+  }
+
+  return $boolReturn
+}
+
+# http://winintro.ru/netsh_technicalreference.en/html/1a736f2d-ecf8-4780-8e0f-85c4db75230b.htm
+function Test-FirewallRule {
+  Param (
+    [string]$Action,
+    [string]$Description,
+    [string]$Name,
+    [string]$Port,
+    [object[]]$Rules
+  )
+  $ActionLowerCase = $Action.ToLower()
+
+  If ($Rules.Count -eq 0) {
+    netsh advfirewall firewall add rule name="$Name" dir="in" action="$ActionLowerCase" description="$Description" localport="$Port" protocol="tcp"
+  } Elseif ($Rules.Count -gt 1) {
+    netsh advfirewall firewall delete rule name="$Name"
+    netsh advfirewall firewall add rule name="$Name" dir="in" action="$ActionLowerCase" description="$Description" localport="$Port" protocol="tcp"
+  } Else {
+    $Rule = $Rules[0]
+    If ($Rule.Action -ne $Action) {
+      netsh advfirewall firewall set rule name="$Name" new action="$ActionLowerCase"
+    }
+  }
+}
+
+Try {
+  $HttpRuleName = "Windows Remote Management (HTTP-In)"
+  $HttpsRuleName = "Windows Remote Management (HTTPS-In)"
+
+  $HttpRules = Get-NetshRule -RuleName $HttpRuleName
+  $HttpsRules = Get-NetshRule -RuleName $HttpsRuleName
+
+  $HttpEnable = Convert-StringToBoolean -BoolString '<%= @http_listener_enable %>'
+  $HttpsEnable = Convert-StringToBoolean -BoolString '<%= @https_listener_enable %>'
+
+  $HttpRuleAction = "Allow"
+  If (!($HttpEnable)) {
+    $HttpRuleAction = "Block"
+  }
+
+  $HttpsRuleAction = "Allow"
+  If (!($HttpsEnable)) {
+    $HttpsRuleAction = "Block"
+  }
+
+  Test-FirewallRule -Action $HttpRuleAction -Description "Inbound rule for Windows Remote Management via WS-Management. [TCP 5985]" -Name $HttpRuleName -Port "5985" -Rules $HttpRules
+  Test-FirewallRule -Action $HttpsRuleAction -Description "Inbound rule for Windows Remote Management via WS-Management. [TCP 5986]" -Name $HttpsRuleName -Port "5986" -Rules $HttpsRules
+} Catch {
+  $exception_str = $_ | Out-String
+  Write-Output "[$(Get-Date -Format 'o')] an error occurred: $exception_str"
+  Exit 1
+}

--- a/templates/firewall/firewall_rules_onlyif.ps1.erb
+++ b/templates/firewall/firewall_rules_onlyif.ps1.erb
@@ -1,0 +1,131 @@
+# Check Firewall configurations
+# -----------------------------------------------------------
+#
+# This script checks the current firewall configurations against
+# what is passed in and changes them if neccessary using netsh
+# commands. We use netsh commands instead of the powershell
+# commandlets due to speed, functionality, and backwards compatibility
+function Get-NetshRule {
+  Param (
+    [string]$RuleName
+  )
+  $AllRules = @()
+
+  # Get all enabled rules
+  $Rules = netsh advfirewall firewall show rule status=enabled name="$RuleName"
+
+  # Check if rules are returened
+  $NoMatchString = "No rules match the specified criteria."
+  If ($Rules -eq $NoMatchString) {
+    Return $AllRules
+  }
+
+  # Verify the return is an array
+  If ($Rules -ne [System.Array] ) {
+    $Rules = @($Rules)
+  }
+
+  $SwitchProperties = @{}
+  ForEach ($Rule in $Rules) {
+    # $RuleObject = @{}
+    # Matches is a variable created by the switch that is an object of the matching text
+    # We add to the list on the last property of the rule because the Switch Regex separates
+    # into individual line creating the object in the current context.
+    # Sample rule below:
+    #   Rule Name:                            Windows Remote Management (HTTP-In)
+    #   ----------------------------------------------------------------------
+    #   Enabled:                              Yes
+    #   Direction:                            In
+    #   Profiles:                             Domain,Private
+    #   Grouping:                             Windows Remote Management
+    #   LocalIP:                              Any
+    #   RemoteIP:                             Any
+    #   Protocol:                             TCP
+    #   LocalPort:                            5985
+    #   RemotePort:                           Any
+    #   Edge traversal:                       No
+    #   Action:                               Allow
+    Switch -Regex ($Rule) {
+      '^Rule Name:\s+(?<RuleName>.*$)' { $SwitchProperties.RuleName = $Matches.RuleName; }
+      '^Enabled:\s+(?<Enabled>.*$)' { $SwitchProperties.Enabled = $Matches.Enabled; }
+      '^Direction:\s+(?<Direction>.*$)' { $SwitchProperties.Direction = $Matches.Direction; }
+      '^Profiles:\s+(?<Profiles>.*$)' { $SwitchProperties.Profiles = $Matches.Profiles; }
+      '^Grouping:\s+(?<Grouping>.*$)' { $SwitchProperties.Grouping = $Matches.Grouping; }
+      '^LocalIP:\s+(?<LocalIP>.*$)' { $SwitchProperties.LocalIP = $Matches.LocalIP; }
+      '^RemoteIP:\s+(?<RemoteIP>.*$)' { $SwitchProperties.RemoteIP = $Matches.RemoteIP; }
+      '^Protocol:\s+(?<Protocol>.*$)' { $SwitchProperties.Protocol = $Matches.Protocol; }
+      '^LocalPort:\s+(?<LocalPort>.*$)' { $SwitchProperties.LocalPort = $Matches.LocalPort; }
+      '^RemotePort:\s+(?<RemotePort>.*$)' { $SwitchProperties.RemotePort = $Matches.RemotePort; }
+      '^Edge traversal:\s+(?<Edge_traversal>.*$)' { $SwitchProperties.EdgeTraversal = $Matches.Edge_traversal; }
+      '^Action:\s+(?<Action>.*$)' { $SwitchProperties.Action = $Matches.Action; $RuleObject = New-Object psobject -Property $SwitchProperties; $AllRules += $RuleObject; }
+      # Ignore any other lines that do not match above. Should only be: -------
+      Default { Break }
+    }
+  }
+
+  Return $AllRules
+}
+
+function Convert-StringToBoolean {
+  Param (
+    [string]$BoolString
+  )
+
+  $boolReturn = $true
+  If ($BoolString.ToLower() -eq 'false') {
+    $boolReturn = $false
+  }
+
+  return $boolReturn
+}
+
+# http://winintro.ru/netsh_technicalreference.en/html/1a736f2d-ecf8-4780-8e0f-85c4db75230b.htm
+function Test-FirewallRule {
+  Param (
+    [string]$Action,
+    [string]$Description,
+    [string]$Name,
+    [string]$Port,
+    [object[]]$Rules
+  )
+  $ActionLowerCase = $Action.ToLower()
+
+  If ($Rules.Count -eq 0) {
+    Exit 1
+  } Elseif ($Rules.Count -gt 1) {
+    Exit 1
+  } Else {
+    $Rule = $Rules[0]
+    If ($Rule.Action -ne $Action) {
+      Exit 1
+    }
+  }
+}
+
+Try {
+  $HttpRuleName = "Windows Remote Management (HTTP-In)"
+  $HttpsRuleName = "Windows Remote Management (HTTPS-In)"
+
+  $HttpRules = Get-NetshRule -RuleName $HttpRuleName
+  $HttpsRules = Get-NetshRule -RuleName $HttpsRuleName
+
+  $HttpEnable = Convert-StringToBoolean -BoolString '<%= @http_listener_enable %>'
+  $HttpsEnable = Convert-StringToBoolean -BoolString '<%= @https_listener_enable %>'
+
+  $HttpRuleAction = "Allow"
+  If (!($HttpEnable)) {
+    $HttpRuleAction = "Block"
+  }
+
+  $HttpsRuleAction = "Allow"
+  If (!($HttpsEnable)) {
+    $HttpsRuleAction = "Block"
+  }
+
+  Test-FirewallRule -Action $HttpRuleAction -Description "Inbound rule for Windows Remote Management via WS-Management. [TCP 5985]" -Name $HttpRuleName -Port "5985" -Rules $HttpRules
+  Test-FirewallRule -Action $HttpsRuleAction -Description "Inbound rule for Windows Remote Management via WS-Management. [TCP 5986]" -Name $HttpsRuleName -Port "5986" -Rules $HttpsRules
+} Catch {
+  $exception_str = $_ | Out-String
+  Write-Output "[$(Get-Date -Format 'o')] an error occurred: $exception_str"
+  Exit 1
+}

--- a/templates/listener/https_listener.ps1.erb
+++ b/templates/listener/https_listener.ps1.erb
@@ -1,0 +1,138 @@
+# HTTPS Listener configurations
+# -----------------------------------------------------------
+#
+# This script checks the current HTTPS listener to see if see
+# if the listener is active and if it should be. Then configures
+# or removes the listener
+Function New-LegacySelfSignedCert
+{
+  Param (
+      [string]$SubjectName,
+      [int]$ValidDays = 1095
+  )
+
+  $hostnonFQDN = $env:computerName
+  $hostFQDN = [System.Net.Dns]::GetHostByName(($env:computerName)).Hostname
+  $SignatureAlgorithm = "SHA256"
+
+  $name = New-Object -COM "X509Enrollment.CX500DistinguishedName.1"
+  $name.Encode("CN=$SubjectName", 0)
+
+  $key = New-Object -COM "X509Enrollment.CX509PrivateKey.1"
+  $key.ProviderName = "Microsoft Enhanced RSA and AES Cryptographic Provider"
+  $key.KeySpec = 1
+  $key.Length = 4096
+  $key.SecurityDescriptor = "D:PAI(A;;0xd01f01ff;;;SY)(A;;0xd01f01ff;;;BA)(A;;0x80120089;;;NS)"
+  $key.MachineContext = 1
+  $key.Create()
+
+  $serverauthoid = New-Object -COM "X509Enrollment.CObjectId.1"
+  $serverauthoid.InitializeFromValue("1.3.6.1.5.5.7.3.1")
+  $ekuoids = New-Object -COM "X509Enrollment.CObjectIds.1"
+  $ekuoids.Add($serverauthoid)
+  $ekuext = New-Object -COM "X509Enrollment.CX509ExtensionEnhancedKeyUsage.1"
+  $ekuext.InitializeEncode($ekuoids)
+
+  $cert = New-Object -COM "X509Enrollment.CX509CertificateRequestCertificate.1"
+  $cert.InitializeFromPrivateKey(2, $key, "")
+  $cert.Subject = $name
+  $cert.Issuer = $cert.Subject
+  $cert.NotBefore = (Get-Date).AddDays(-1)
+  $cert.NotAfter = $cert.NotBefore.AddDays($ValidDays)
+
+  $SigOID = New-Object -ComObject X509Enrollment.CObjectId
+  $SigOID.InitializeFromValue(([Security.Cryptography.Oid]$SignatureAlgorithm).Value)
+
+  [string[]] $AlternativeName  += $hostnonFQDN
+  $AlternativeName += $hostFQDN
+  $IAlternativeNames = New-Object -ComObject X509Enrollment.CAlternativeNames
+
+  foreach ($AN in $AlternativeName) {
+    $AltName = New-Object -ComObject X509Enrollment.CAlternativeName
+    $AltName.InitializeFromString(0x3,$AN)
+    $IAlternativeNames.Add($AltName)
+  }
+
+  $SubjectAlternativeName = New-Object -ComObject X509Enrollment.CX509ExtensionAlternativeNames
+  $SubjectAlternativeName.InitializeEncode($IAlternativeNames)
+
+  [String[]]$KeyUsage = ("DigitalSignature", "KeyEncipherment")
+  $KeyUsageObj = New-Object -ComObject X509Enrollment.CX509ExtensionKeyUsage
+  $KeyUsageObj.InitializeEncode([int][Security.Cryptography.X509Certificates.X509KeyUsageFlags]($KeyUsage))
+  $KeyUsageObj.Critical = $true
+
+  $cert.X509Extensions.Add($KeyUsageObj)
+  $cert.X509Extensions.Add($ekuext)
+  $cert.SignatureInformation.HashAlgorithm = $SigOID
+  $CERT.X509Extensions.Add($SubjectAlternativeName)
+  $cert.Encode()
+
+  $enrollment = New-Object -COM "X509Enrollment.CX509Enrollment.1"
+  $enrollment.InitializeFromRequest($cert)
+  $certdata = $enrollment.CreateRequest(0)
+  $enrollment.InstallResponse(2, $certdata, 0, "")
+
+  # extract/return the thumbprint from the generated cert
+  $parsed_cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
+  $parsed_cert.Import([System.Text.Encoding]::UTF8.GetBytes($certdata))
+
+  return $parsed_cert.Thumbprint
+}
+
+# Puppet does not give the booleans to powershell in the correct way, they are given as strings.
+# So once given we need to convert them to true booleans so that the logic below will work
+function Convert-StringToBoolean {
+  Param (
+    [string]$BoolString
+  )
+
+  $boolReturn = $true
+  If ($BoolString.ToLower() -eq 'false') {
+    $boolReturn = $false
+  }
+
+  return $boolReturn
+}
+
+# Setup error handling.
+$ErrorActionPreference = "Stop"
+
+Try {
+  $SubjectName = $env:COMPUTERNAME
+  $BasicEnable = Convert-StringToBoolean -BoolString '<%= @https_listener_enable %>'
+  $CertificateHash = '<%= @certificate_hash %>'
+  $CertValidityDays = <%= @cert_validity_days %>
+
+  $selectorset = @{
+    Transport = "HTTPS"
+    Address = "*"
+  }
+
+  $listeners = Get-ChildItem WSMan:\localhost\Listener
+  # True
+  If ($HttpsListenerEnable) {
+    If (!($listeners | Where {$_.Keys -like "TRANSPORT=HTTPS"})) {
+      # Create the hashtables of settings to be used.
+      $valueset = @{
+        Hostname = $SubjectName
+      }
+
+      If ($CertificateHash) {
+        $valueset['CertificateThumbprint'] = $CertificateHash
+      } Else {
+        $valueset['CertificateThumbprint'] = New-LegacySelfSignedCert -SubjectName $SubjectName -ValidDays $CertValidityDays
+      }
+
+      New-WSManInstance -ResourceURI 'winrm/config/Listener' -SelectorSet $selectorset -ValueSet $valueset
+    }
+  # False
+  } Else {
+    If (($listeners | Where {$_.Keys -like "TRANSPORT=HTTPS"})) {
+      Remove-WSManInstance -ResourceURI 'winrm/config/Listener' -SelectorSet $selectorset
+    }
+  }
+} Catch {
+  $exception_str = $_ | Out-String
+  Write-Output "[$(Get-Date -Format 'o')] an error occurred: $exception_str"
+  Exit 1
+}

--- a/templates/listener/https_listener.ps1.erb
+++ b/templates/listener/https_listener.ps1.erb
@@ -99,7 +99,7 @@ $ErrorActionPreference = "Stop"
 
 Try {
   $SubjectName = $env:COMPUTERNAME
-  $BasicEnable = Convert-StringToBoolean -BoolString '<%= @https_listener_enable %>'
+  $HttpsListenerEnable = Convert-StringToBoolean -BoolString '<%= @https_listener_enable %>'
   $CertificateHash = '<%= @certificate_hash %>'
   $CertValidityDays = <%= @cert_validity_days %>
 

--- a/templates/listener/https_listener_onlyif.ps1.erb
+++ b/templates/listener/https_listener_onlyif.ps1.erb
@@ -1,0 +1,55 @@
+# Check HTTPS Listener configurations
+# -----------------------------------------------------------
+#
+# This script checks the current HTTPS listener to see if see
+# if the listener is active and if it should be.
+
+# Puppet does not give the booleans to powershell in the correct way, they are given as strings.
+# So once given we need to convert them to true booleans so that the logic below will work
+function Convert-StringToBoolean {
+  Param (
+    [string]$BoolString
+  )
+
+  $boolReturn = $true
+  If ($BoolString.ToLower() -eq 'false') {
+    $boolReturn = $false
+  }
+
+  return $boolReturn
+}
+
+# Setup error handling.
+$ErrorActionPreference = "Stop"
+
+Try {
+  $SubjectName = $env:COMPUTERNAME
+  $HttpsListenerEnable = Convert-StringToBoolean -BoolString '<%= @https_listener_enable %>'
+  $CertificateHash = '<%= @certificate_hash %>'
+  $CertValidityDays = <%= @cert_validity_days %>
+
+  $listeners = Get-ChildItem WSMan:\localhost\Listener
+  # True
+  If ($HttpsListenerEnable) {
+    If (!($listeners | Where {$_.Keys -like "TRANSPORT=HTTPS"})) {
+      # No ssl listener and there there should be
+      Exit 0
+    } Else {
+      # Ssl listener and there there should be
+      Exit 1
+    }
+  # False
+  } Else {
+    If (($listeners | Where {$_.Keys -like "TRANSPORT=HTTPS"})) {
+      # Ssl listener and there should not be
+      Exit 0
+    } Else {
+      # No ssl listener and there should not be
+      Exit 1
+    }
+  }
+} Catch {
+  $exception_str = $_ | Out-String
+  Write-Output "[$(Get-Date -Format 'o')] an error occurred: $exception_str"
+  Exit 1
+}


### PR DESCRIPTION
Added all classes needed to configure WinRM on Windows systems.

We are not using windows_firewall module due to issues maintaining the state of the firewall rules. Will revisit later after updates are made to module.

Classes:
allow_unencrypted
ps_remoting
execution_policy
localaccounttokenfilter
auth
listener::http
listener::https
firewall

Added tests for all classes with 100% code coverage:
```
Finished in 20.92 seconds (files took 1 minute 19.21 seconds to load)
120 examples, 0 failures

.Total resources:   22
Touched resources: 22
Resource coverage: 100.00%
```